### PR TITLE
fix: await cookies in Supabase server client

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 
 export async function login(prevState: any, formData: FormData) {
-  const supabase = createClient()
+  const supabase = await createClient()
 
   const email = formData.get("email")
   const password = formData.get("password")
@@ -30,7 +30,7 @@ export async function login(prevState: any, formData: FormData) {
 }
 
 export async function signup(prevState: any, formData: FormData) {
-  const supabase = createClient()
+  const supabase = await createClient()
 
   const email = formData.get("email")
   const password = formData.get("password")
@@ -69,7 +69,7 @@ export async function signup(prevState: any, formData: FormData) {
 }
 
 export async function signOut() {
-  const supabase = createClient()
+  const supabase = await createClient()
   await supabase.auth.signOut()
   redirect("/login")
 }

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { revalidatePath } from "next/cache"
 
 export default async function AdminDashboardPage() {
-  const supabase = createClient()
+  const supabase = await createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
@@ -26,7 +26,7 @@ export default async function AdminDashboardPage() {
 
   async function approveClient(formData: FormData) {
     "use server"
-    const supabase = createClient()
+    const supabase = await createClient()
     const clientId = formData.get("clientId") as string
     const status = formData.get("status") === "true"
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,8 +1,8 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr"
 import { cookies } from "next/headers"
 
-export function createClient() {
-  const cookieStore = cookies()
+export async function createClient() {
+  const cookieStore = await cookies()
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY


### PR DESCRIPTION
## Summary
- ensure Supabase server client uses async cookie API
- await server client creation in auth actions and admin dashboard

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm exec tsc --noEmit` *(fails: Property 'items' does not exist on type 'CartContextType', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68912d30ffec832cb6c03e6eb8d18e08