### PR TITLE
fix: parse qualigens product data

### DIFF
--- a/lib/qualigens-products.ts
+++ b/lib/qualigens-products.ts
@@ -4,7 +4,7 @@ export interface QualigensProduct {
   name: string
   packSize: string
   material: string
-  price: string
+  price: number
   hsn: string
   category?: string
   purity?: string
@@ -17,13 +17,21 @@ import qualigensDataRaw from "./qualigens-products.json"
 const raw = Array.isArray(qualigensDataRaw?.data)
   ? qualigensDataRaw.data
   : Array.isArray(qualigensDataRaw)
-  ? qualigensDataRaw
-  : []
+    ? qualigensDataRaw
+    : []
 
-export const qualigensProducts: QualigensProduct[] = raw.map(
-  ([code, cas, name, packSize, material, price, hsn]) => ({
+export const qualigensProducts: QualigensProduct[] = raw.map((item) => {
+  const code = item["Product Code"] || ""
+  const cas = item["CAS No"] || ""
+  const name = item["Product Name"] || ""
+  const packSize = item["Pack Size"] || ""
+  const material = item["Packing"] || ""
+  const price = Number(item["Price"] || 0)
+  const hsn = item["HSN Code"] || ""
+
+  return {
     code,
-    cas: cas || "",
+    cas,
     name,
     packSize,
     material,
@@ -33,7 +41,7 @@ export const qualigensProducts: QualigensProduct[] = raw.map(
     purity: "SQ",
     brand: "Qualigens",
     id: code,
-  })
-)
+  }
+})
 
 export default qualigensProducts


### PR DESCRIPTION
## Summary
- handle object-formatted Qualigens JSON and parse numeric price

## Testing
- `pnpm run lint` *(fails: How would you like to configure ESLint?)*
- `pnpm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689133d7b1e4832c91511b9b396c2e72