### PR TITLE
Handle flexible Qualigens JSON import

### DIFF
--- a/lib/qualigens-products.ts
+++ b/lib/qualigens-products.ts
@@ -12,12 +12,13 @@ export interface QualigensProduct {
   id?: string
 }
 
-import qualigensDataRaw from "./qualigens-products.json"
+import * as qualigensDataRaw from "./qualigens-products.json"
 
-const raw = Array.isArray(qualigensDataRaw?.data)
-  ? qualigensDataRaw.data
-  : Array.isArray(qualigensDataRaw)
-    ? qualigensDataRaw
+const rawQualigensData = (qualigensDataRaw as any).default || qualigensDataRaw
+const raw = Array.isArray(rawQualigensData?.data)
+  ? rawQualigensData.data
+  : Array.isArray(rawQualigensData)
+    ? rawQualigensData
     : []
 
 export const qualigensProducts: QualigensProduct[] = raw.map((item) => {


### PR DESCRIPTION
## Summary
- normalize Qualigens product JSON import to handle default and raw module structures
- map products from a unified `raw` data array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68913a7d5b90832cbb3a9cb8564eb0f7