### PR TITLE
Handle missing product names in Qualigens sort

### DIFF
--- a/app/products/qualigens/page.tsx
+++ b/app/products/qualigens/page.tsx
@@ -20,8 +20,10 @@ export default function QualigensPage() {
 
   // Sort products alphabetically by name
   const sortedProducts = useMemo(() => {
-    return [...qualigensProducts].sort((a, b) => a.name.localeCompare(b.name))
-  }, [])
+    return [...qualigensProducts].sort((a, b) =>
+      (a.name || "").localeCompare(b.name || "")
+    )
+  }, [qualigensProducts])
 
   // Filter products based on search and letter selection
   const filteredProducts = useMemo(() => {


### PR DESCRIPTION
## Summary
- prevent crashes when Qualigens product names are missing by defaulting to empty strings in sorting
- update memoization dependencies for product sorting

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689196cde4dc832c8a4310be37ef0ec3