### PR TITLE
fix: persist auth and add quotation features

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,16 +2,16 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { createClient } from "@/lib/supabase/client"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
   const router = useRouter()
-  const supabase = createClientComponentClient()
+  const supabase = createClient()
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/app/admin/quotation/page.tsx
+++ b/app/admin/quotation/page.tsx
@@ -1,12 +1,18 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { Download } from "lucide-react"
+import { useAuth } from "@/app/context/auth-context"
+import borosilProducts from "@/lib/borosil_products_absolute_final.json"
+import rankemProducts from "@/lib/rankem_products.json"
+import { qualigensProducts } from "@/lib/qualigens-products"
+import whatmanProducts from "@/lib/whatman_products.json"
+import jsPDF from "jspdf"
 
 interface QuotationItem {
   id: number
@@ -18,7 +24,48 @@ interface QuotationItem {
   custom: boolean
 }
 
+const allProducts: any[] = [
+  ...(borosilProducts as any[]).flatMap(group =>
+    (group.variants || []).map((v: any) => ({
+      name: v.name || group.product || "",
+      brand: "Borosil",
+      packSize: v.packSize || v["Pack Size"] || (v.capacity_ml ? `${v.capacity_ml} ml` : ""),
+      price: typeof v.price === "number" ? v.price : Number(v.price) || 0,
+    }))
+  ),
+  ...(rankemProducts as any[]).flatMap(group =>
+    (group.variants || []).map((v: any) => ({
+      name: v["Description"] || v["Unnamed: 1"] || "",
+      brand: "Rankem",
+      packSize:
+        v["Pack\nSize"] || v["Pack Size"] || v["Pack size"] || v["Unnamed: 3"] || "",
+      price:
+        typeof v["List Price\n2025(INR)"] === "number"
+          ? v["List Price\n2025(INR)"]
+          : typeof v.Price === "number"
+            ? v.Price
+            : typeof v["Unnamed: 5"] === "number"
+              ? v["Unnamed: 5"]
+              : 0,
+    }))
+  ),
+  ...qualigensProducts.map(p => ({
+    name: p.name,
+    brand: "Qualigens",
+    packSize: p.packSize,
+    price: p.price,
+  })),
+  ...(((whatmanProducts as any)?.variants) || []).map((v: any) => ({
+    name: v.name || v["name"],
+    brand: "Whatman",
+    packSize: "",
+    price: typeof v.price === "number" ? v.price : Number(v.price) || 0,
+  })),
+]
+
 export default function QuotationBuilder() {
+  const { user, role, loading } = useAuth()
+  const router = useRouter()
   const [items, setItems] = useState<QuotationItem[]>([])
   const [form, setForm] = useState({
     productName: "",
@@ -27,6 +74,41 @@ export default function QuotationBuilder() {
     quantity: "",
     price: "",
   })
+  const [matches, setMatches] = useState<any[]>([])
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user) router.replace("/login")
+      else if (role !== "admin") router.replace("/dashboard")
+    }
+  }, [user, role, loading, router])
+
+  useEffect(() => {
+    const search = form.productName
+    if (search.trim().length > 1) {
+      const query = search.toLowerCase().replace(/[^a-z0-9]/g, "")
+      const filtered = allProducts.filter(p => {
+        const key = (p.name + p.brand + (p.packSize || ""))
+          .toLowerCase()
+          .replace(/[^a-z0-9]/g, "")
+        return key.includes(query)
+      })
+      setMatches(filtered.slice(0, 10))
+    } else {
+      setMatches([])
+    }
+  }, [form.productName])
+
+  const handleSelect = (product: any) => {
+    setForm({
+      productName: product.name,
+      brand: product.brand,
+      packSize: product.packSize || "",
+      quantity: "",
+      price: product.price ? String(product.price) : "",
+    })
+    setMatches([])
+  }
 
   const handleAdd = () => {
     if (!form.productName || !form.quantity || !form.price) return
@@ -46,10 +128,42 @@ export default function QuotationBuilder() {
   }
 
   const removeItem = (id: number) => {
-    setItems(items.filter((item) => item.id !== id))
+    setItems(items.filter(item => item.id !== id))
+  }
+
+  const exportPDF = () => {
+    const doc = new jsPDF()
+    doc.setFontSize(16)
+    doc.text("Chemical Corporation, Ludhiana", 14, 20)
+
+    doc.setFontSize(12)
+    let y = 30
+    doc.text("Product", 14, y)
+    doc.text("Brand", 60, y)
+    doc.text("Pack Size", 90, y)
+    doc.text("Qty", 120, y)
+    doc.text("Price", 140, y)
+    doc.text("Total", 170, y)
+    y += 6
+
+    items.forEach(item => {
+      doc.text(item.productName, 14, y)
+      doc.text(item.brand, 60, y)
+      doc.text(item.packSize, 90, y)
+      doc.text(String(item.quantity), 120, y)
+      doc.text(item.price.toFixed(2), 140, y)
+      doc.text((item.price * item.quantity).toFixed(2), 170, y)
+      y += 6
+    })
+
+    y += 4
+    doc.text(`Total: ₹${totalAmount.toFixed(2)}`, 14, y)
+    doc.save("quotation.pdf")
   }
 
   const totalAmount = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+
+  if (loading || role !== "admin") return null
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -63,25 +177,52 @@ export default function QuotationBuilder() {
           <CardTitle>Add Product to Quotation</CardTitle>
         </CardHeader>
         <CardContent className="grid grid-cols-1 md:grid-cols-5 gap-4">
-          <div>
+          <div className="md:col-span-2">
             <Label>Product Name</Label>
-            <Input value={form.productName} onChange={(e) => setForm({ ...form, productName: e.target.value })} />
+            <div className="relative">
+              <Input
+                value={form.productName}
+                onChange={e => setForm({ ...form, productName: e.target.value })}
+                placeholder="Type to search..."
+              />
+              {matches.length > 0 && (
+                <div className="absolute bg-white border w-full shadow-md max-h-60 overflow-y-auto z-10">
+                  {matches.map((item, idx) => (
+                    <div
+                      key={idx}
+                      className="p-2 hover:bg-gray-100 cursor-pointer"
+                      onClick={() => handleSelect(item)}
+                    >
+                      {item.name} <span className="text-xs text-gray-500">({item.brand})</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
           <div>
             <Label>Brand</Label>
-            <Input value={form.brand} onChange={(e) => setForm({ ...form, brand: e.target.value })} />
+            <Input value={form.brand} onChange={e => setForm({ ...form, brand: e.target.value })} />
           </div>
           <div>
             <Label>Pack Size</Label>
-            <Input value={form.packSize} onChange={(e) => setForm({ ...form, packSize: e.target.value })} />
+            <Input value={form.packSize} onChange={e => setForm({ ...form, packSize: e.target.value })} />
           </div>
           <div>
             <Label>Quantity</Label>
-            <Input type="number" value={form.quantity} onChange={(e) => setForm({ ...form, quantity: e.target.value })} />
+            <Input
+              type="number"
+              value={form.quantity}
+              onChange={e => setForm({ ...form, quantity: e.target.value })}
+            />
           </div>
           <div>
             <Label>Price</Label>
-            <Input type="number" value={form.price} onChange={(e) => setForm({ ...form, price: e.target.value })} />
+            <Input
+              type="number"
+              value={form.price}
+              onChange={e => setForm({ ...form, price: e.target.value })}
+            />
           </div>
           <div className="md:col-span-5 text-right">
             <Button onClick={handleAdd}>Add</Button>
@@ -108,7 +249,7 @@ export default function QuotationBuilder() {
                 </tr>
               </thead>
               <tbody>
-                {items.map((item) => (
+                {items.map(item => (
                   <tr key={item.id} className="border-b">
                     <td className="py-2">{item.productName}</td>
                     <td className="text-center">{item.brand}</td>
@@ -127,7 +268,7 @@ export default function QuotationBuilder() {
             </table>
             <div className="text-right font-semibold mt-4 text-lg">Total: ₹{totalAmount.toFixed(2)}</div>
             <div className="mt-4 text-right">
-              <Button variant="outline">
+              <Button variant="outline" onClick={exportPDF}>
                 <Download className="mr-2 h-4 w-4" /> Export as PDF
               </Button>
             </div>
@@ -137,3 +278,4 @@ export default function QuotationBuilder() {
     </div>
   )
 }
+

--- a/app/context/auth-context.tsx
+++ b/app/context/auth-context.tsx
@@ -17,7 +17,12 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
-  const [role, setRole] = useState<string | null>(null)
+  const [role, setRole] = useState<string | null>(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("user_role")
+    }
+    return null
+  })
   const supabase = useMemo(() => createClient(), [])
 
   useEffect(() => {
@@ -38,12 +43,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
           if (!error && data?.role) {
             setRole(data.role)
+            localStorage.setItem("user_role", data.role)
           }
         }
       } catch (error) {
         console.error("Error getting session or role:", error)
         setUser(null)
         setRole(null)
+        localStorage.removeItem("user_role")
       } finally {
         setLoading(false)
       }
@@ -67,11 +74,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         if (!error && data?.role) {
           setRole(data.role)
+          localStorage.setItem("user_role", data.role)
         } else {
           setRole(null)
+          localStorage.removeItem("user_role")
         }
       } else {
         setRole(null)
+        localStorage.removeItem("user_role")
       }
     })
 
@@ -83,6 +93,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await supabase.auth.signOut()
       setUser(null)
       setRole(null)
+      localStorage.removeItem("user_role")
     } catch (error) {
       console.error("Error signing out:", error)
     }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -26,20 +26,19 @@ import {
   TestTube,
   Microscope,
   FlaskConical,
+  ClipboardList,
+  FileText,
 } from "lucide-react"
 import { useAuth } from "@/app/context/auth-context"
 import { useCart } from "@/app/context/CartContext"
 import { Input } from "@/components/ui/input"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 
 export function Header() {
-  const { user, signOut } = useAuth()
+  const { user, role, signOut } = useAuth()
   const { state } = useCart()
   const [mounted, setMounted] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
-  const [isAdmin, setIsAdmin] = useState(false)
   const router = useRouter()
-  const supabase = createClientComponentClient()
 
   useEffect(() => {
     setMounted(true)
@@ -54,27 +53,6 @@ export function Header() {
       setSearchQuery("")
     }
   }
-
-  useEffect(() => {
-    const checkAdmin = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      if (!session?.user) return
-
-      const { data } = await supabase
-        .from("profiles")
-        .select("role")
-        .eq("id", session.user.id)
-        .single()
-
-      if (data?.role === "admin") {
-        setIsAdmin(true)
-      }
-    }
-
-    checkAdmin()
-  }, [supabase])
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
@@ -182,23 +160,6 @@ export function Header() {
               Contact
             </Link>
 
-            {/* 🧾 Admin Links */}
-            {isAdmin && (
-              <>
-                <Link
-                  href="/admin/restock"
-                  className="text-sm font-medium hover:text-blue-600 transition-colors"
-                >
-                  🧾 Restock Dashboard
-                </Link>
-                <Link
-                  href="/admin/quotation"
-                  className="text-sm font-medium hover:text-blue-600 transition-colors"
-                >
-                  📄 Quotation Builder
-                </Link>
-              </>
-            )}
           </nav>
 
           {/* Right side actions */}
@@ -252,6 +213,23 @@ export function Header() {
                       My Orders
                     </Link>
                   </DropdownMenuItem>
+                  {role === "admin" && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem asChild>
+                        <Link href="/admin/restock" className="flex items-center">
+                          <ClipboardList className="mr-2 h-4 w-4" />
+                          Restock Dashboard
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <Link href="/admin/quotation" className="flex items-center">
+                          <FileText className="mr-2 h-4 w-4" />
+                          Quotation Builder
+                        </Link>
+                      </DropdownMenuItem>
+                    </>
+                  )}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={signOut} className="flex items-center text-red-600">
                     <LogOut className="mr-2 h-4 w-4" />

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -9,5 +9,11 @@ export function createClient() {
   }
 
   // Create a supabase client on the browser with project's credentials
-  return createBrowserClient(supabaseUrl, supabaseAnonKey)
+  // and ensure the session is persisted across refreshes.
+  return createBrowserClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  })
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "jspdf": "^2.5.1",
     "vaul": "^0.9.6",
     "zod": "^3.24.1"
   },


### PR DESCRIPTION
## Summary
- persist Supabase sessions and cache profile role
- show admin-only navigation links
- add dynamic product lookup and PDF export to quotation builder

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/jspdf: Forbidden - 403)*
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689391f7698c832cb552208d2a9091a6