### PR TITLE
feat: lab-themed layout and admin access control

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -61,11 +61,14 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
-      <Card className="w-full max-w-md p-6 shadow-lg">
+    <div className="relative min-h-screen flex items-center justify-center bg-[url('/images/hero-background.png')] bg-cover bg-center">
+      <div className="absolute inset-0 bg-white/80 backdrop-blur-md" />
+      <Card className="relative w-full max-w-md p-6 shadow-xl bg-white/60 backdrop-blur-md border border-white/40">
         <CardHeader className="space-y-2 text-center">
           <Image src="/placeholder-logo.png" alt="Chemical Corporation" width={48} height={48} className="mx-auto" />
-          <CardTitle className="text-2xl">Login to Chemical Corporation Portal</CardTitle>
+          <CardTitle className="text-2xl bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent">
+            Login to Chemical Corporation Portal
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleLogin} className="space-y-4">
@@ -78,6 +81,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
+                className="bg-white/70 backdrop-blur-sm"
               />
             </div>
             <div className="space-y-2">
@@ -89,6 +93,7 @@ export default function LoginPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
+                className="bg-white/70 backdrop-blur-sm"
               />
             </div>
             {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/app/admin/quotation/page.tsx
+++ b/app/admin/quotation/page.tsx
@@ -3,12 +3,12 @@
 export const dynamic = "force-dynamic"
 
 import { useState } from "react"
-import { notFound } from "next/navigation"
 import { useAuth } from "@/app/context/auth-context"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
+import { AccessDenied } from "@/components/access-denied"
 import { Download, Send } from "lucide-react"
 import jsPDF from "jspdf"
 
@@ -46,7 +46,7 @@ interface ProductEntry {
 export default function QuotationBuilder() {
   const { role, loading } = useAuth()
   if (!loading && role !== "admin") {
-    notFound()
+    return <AccessDenied />
   }
 
   const [items, setItems] = useState<QuotationItem[]>([])

--- a/app/admin/restock/page.tsx
+++ b/app/admin/restock/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
 import { useState } from "react"
-import { notFound } from "next/navigation"
 import { useAuth } from "@/app/context/auth-context"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
+import { AccessDenied } from "@/components/access-denied"
 
 import borosilProducts from "@/lib/borosil_products_absolute_final.json"
 import rankemProducts from "@/lib/rankem_products.json"
@@ -41,7 +41,7 @@ interface ProductEntry {
 export default function RestockPage() {
   const { role, loading } = useAuth()
   if (!loading && role !== "admin") {
-    notFound()
+    return <AccessDenied />
   }
 
   const [items, setItems] = useState<RestockItem[]>([])

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import ClientProviders from "./providers";
+import { Header } from "@/components/header";
+import { Footer } from "@/components/footer";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,7 +21,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={inter.className}>
         {/* All client-stateful code lives inside ClientProviders */}
         <ClientProviders>
-          <main className="min-h-screen">{children}</main>
+          <div className="flex min-h-screen flex-col">
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </div>
         </ClientProviders>
       </body>
     </html>

--- a/components/access-denied.tsx
+++ b/components/access-denied.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import Link from "next/link"
+import { ShieldAlert } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function AccessDenied() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center p-6 bg-gradient-to-br from-white to-blue-50">
+      <ShieldAlert className="w-16 h-16 text-blue-600 mb-4" />
+      <h2 className="text-2xl font-semibold mb-2">Access Denied</h2>
+      <p className="text-muted-foreground mb-6 max-w-md">
+        You need administrative privileges to view this page.
+      </p>
+      <div className="flex gap-3">
+        <Button asChild>
+          <Link href="/login">Login</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/">Back to Home</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default AccessDenied


### PR DESCRIPTION
## Summary
- add global header and footer
- redesign login with glassy laboratory theme
- restrict admin tools with Access Denied screen

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689455952c80832cba0643aa39a8cfbe