### PR TITLE
refactor: centralize search state and fix layout

### DIFF
--- a/app/brand/whatman/page.tsx
+++ b/app/brand/whatman/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { notFound } from "next/navigation"
 import { useCart } from "@/app/context/CartContext"
 import { useToast } from "@/hooks/use-toast"
@@ -8,6 +8,7 @@ import { labSupplyBrands } from "@/lib/data"
 import whatmanProducts from "@/lib/whatman_products.json"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { useSearch } from "@/app/context/search-context"
 
 const normalizeKey = (key: string) =>
   key?.toLowerCase().replace(/[^a-z0-9]/gi, "").trim()
@@ -19,7 +20,7 @@ export default function BrandPage({ params }: { params: { brandName: string } })
 
   const { addItem, isLoaded } = useCart()
   const { toast } = useToast()
-  const [searchTerm, setSearchTerm] = useState("")
+  const { searchQuery, setSearchQuery } = useSearch()
   const [page, setPage] = useState(1)
   const itemsPerPage = 50
 
@@ -27,7 +28,7 @@ export default function BrandPage({ params }: { params: { brandName: string } })
 
   const filteredVariants = group.variants.filter((variant) =>
     Object.values(variant).some((val) =>
-      String(val).toLowerCase().includes(searchTerm.toLowerCase())
+      String(val).toLowerCase().includes(searchQuery.toLowerCase())
     )
   )
 
@@ -36,6 +37,10 @@ export default function BrandPage({ params }: { params: { brandName: string } })
     (page - 1) * itemsPerPage,
     page * itemsPerPage
   )
+
+  useEffect(() => {
+    setPage(1)
+  }, [searchQuery])
 
   const handleAddToCart = (variant: any) => {
     addItem({
@@ -56,11 +61,8 @@ export default function BrandPage({ params }: { params: { brandName: string } })
       <Input
         placeholder="Search by name, code, price, etc."
         className="mb-6"
-        value={searchTerm}
-        onChange={(e) => {
-          setSearchTerm(e.target.value)
-          setPage(1) // Reset to first page on new search
-        }}
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
       />
 
       <div className="overflow-x-auto">

--- a/app/context/search-context.tsx
+++ b/app/context/search-context.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface SearchContextType {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+}
+
+const SearchContext = createContext<SearchContextType | undefined>(undefined);
+
+export function SearchProvider({ children }: { children: ReactNode }) {
+  const [searchQuery, setSearchQuery] = useState("");
+  return (
+    <SearchContext.Provider value={{ searchQuery, setSearchQuery }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function useSearch() {
+  const context = useContext(SearchContext);
+  if (!context) {
+    throw new Error("useSearch must be used within a SearchProvider");
+  }
+  return context;
+}

--- a/app/products/search/page.tsx
+++ b/app/products/search/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Search, Plus } from "lucide-react"
 import { useCart } from "@/app/context/CartContext"
+import { useSearch } from "@/app/context/search-context"
 import { useToast } from "@/hooks/use-toast"
 
 import qualigensProducts from "@/lib/qualigens-products.json"
@@ -21,8 +22,7 @@ function SearchResults() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const initialQuery = searchParams.get("q") || ""
-
-  const [searchQuery, setSearchQuery] = useState(initialQuery)
+  const { searchQuery, setSearchQuery } = useSearch()
   const [searchResults, setSearchResults] = useState<any[]>([])
   const [currentPage, setCurrentPage] = useState(1)
   const resultsPerPage = 50
@@ -179,9 +179,10 @@ function SearchResults() {
 
   useEffect(() => {
     if (initialQuery) {
+      setSearchQuery(initialQuery)
       triggerSearch(initialQuery)
     }
-  }, [initialQuery])
+  }, [initialQuery, setSearchQuery])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,21 +5,20 @@ import React from "react";
 import { AuthProvider } from "@/app/context/auth-context";
 import { QuoteProvider } from "@/app/context/quote-context";
 import { CartProvider } from "@/app/context/CartContext";
+import { SearchProvider } from "@/app/context/search-context";
 import { Toaster } from "@/components/ui/toaster";
 import { WhatsAppButton } from "@/components/whatsapp-button";
-import { Header } from "@/components/header";
-import { Footer } from "@/components/footer";
 
 export default function ClientProviders({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
       <QuoteProvider>
         <CartProvider>
-          <Header />
-          {children}
-          <Footer />
-          <WhatsAppButton />
-          <Toaster />
+          <SearchProvider>
+            {children}
+            <WhatsAppButton />
+            <Toaster />
+          </SearchProvider>
         </CartProvider>
       </QuoteProvider>
     </AuthProvider>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
@@ -32,12 +32,13 @@ import {
 import { useAuth } from "@/app/context/auth-context"
 import { useCart } from "@/app/context/CartContext"
 import { Input } from "@/components/ui/input"
+import { useSearch } from "@/app/context/search-context"
 
 export function Header() {
   const { user, role, signOut } = useAuth()
   const { state } = useCart()
+  const { searchQuery, setSearchQuery } = useSearch()
   const [mounted, setMounted] = useState(false)
-  const [searchQuery, setSearchQuery] = useState("")
   const router = useRouter()
 
   useEffect(() => {
@@ -50,7 +51,6 @@ export function Header() {
     e.preventDefault()
     if (searchQuery.trim()) {
       router.push(`/products/search?q=${encodeURIComponent(searchQuery)}`)
-      setSearchQuery("")
     }
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate header/footer by wrapping app in a single provider
- share search input state across pages with new `SearchContext`
- filter brand pages to only show variants that match the search query

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68945bd94658832cb70dac75d7b14501