### PR TITLE
fix docxtemplater server config

### DIFF
--- a/app/admin/quotation/utils/fillQuoteTemplate.ts
+++ b/app/admin/quotation/utils/fillQuoteTemplate.ts
@@ -1,14 +1,19 @@
 "use server";
 
-import PizZip from "pizzip";
-import Docxtemplater from "docxtemplater";
-const PizZip = require("pizzip");
-const Docxtemplater = require("docxtemplater");
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
-async function generateQuoteDocx(data) {
-  const filePath = path.join(process.cwd(), "app", "admin", "quotation", "quote template.docx");
+export async function generateQuoteDocx(data) {
+  const PizZip = (await import("pizzip")).default;
+  const Docxtemplater = (await import("docxtemplater")).default;
+
+  const filePath = path.join(
+    process.cwd(),
+    "app",
+    "admin",
+    "quotation",
+    "quote template.docx",
+  );
   const content = fs.readFileSync(filePath, "binary");
 
   const zip = new PizZip(content);
@@ -25,5 +30,3 @@ async function generateQuoteDocx(data) {
   const buffer = doc.getZip().generate({ type: "nodebuffer" });
   return buffer;
 }
-
-module.exports = { generateQuoteDocx };

--- a/app/api/generate-quote/route.ts
+++ b/app/api/generate-quote/route.ts
@@ -1,6 +1,6 @@
 // app/api/generate-quote/route.ts
 import { NextResponse } from "next/server";
-const { generateQuoteDocx } = require("@/app/admin/quotation/utils/fillQuoteTemplate");
+import { generateQuoteDocx } from "@/app/admin/quotation/utils/fillQuoteTemplate";
 
 export async function POST(req: Request) {
   const body = await req.json(); // contains tags like { client, date, products, etc. }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ["docxtemplater", "pizzip"],
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "geist": "^1.3.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
+    "docxtemplater": "^3.43.0",
+    "pizzip": "^3.1.4",
     "next": "15.2.4",
     "next-themes": "^0.4.4",
     "react": "^19",


### PR DESCRIPTION
## Summary
- load docxtemplater and pizzip with dynamic imports for server route
- allow docx libraries as external server packages and update API route imports
- add docxtemplater and pizzip to dependencies

## Testing
- `pnpm build` *(fails: Module not found: Can't resolve 'pizzip')*


------
https://chatgpt.com/codex/tasks/task_e_6894af5261a4832cb475c3959c4093c6