### PR TITLE
Fix docx generation deps for Next.js build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  serverExternalPackages: ["docxtemplater", "pizzip"],
   eslint: {
     ignoreDuringBuilds: true,
   },
@@ -11,16 +10,6 @@ const nextConfig = {
     unoptimized: true,
   },
   transpilePackages: ["docxtemplater", "pizzip"],
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      // Prevent bundling of server-only libraries in client build
-      config.externals.push({
-        docxtemplater: "commonjs2 docxtemplater",
-        pizzip: "commonjs2 pizzip",
-      });
-    }
-    return config;
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start",
-    "postinstall": "pnpm install --no-frozen-lockfile"
+    "start": "next start"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       docxtemplater:
-        specifier: ^3.43.0
+        specifier: ^3.65.2
         version: 3.65.2
       embla-carousel-react:
         specifier: 8.5.1


### PR DESCRIPTION
## Summary
- simplify Next.js config to transpile `docxtemplater` and `pizzip`
- remove custom postinstall to avoid lockfile issues
- update lockfile to include docx generation packages

## Testing
- `pnpm install`
- `pnpm build` *(fails: Failed to fetch Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6894d406eeac832cb97c2f29f606b35a