### PR TITLE
feat: add searchable product dropdowns for admin tools

### DIFF
--- a/app/admin/quotation/page.tsx
+++ b/app/admin/quotation/page.tsx
@@ -14,6 +14,7 @@ interface QuotationItem {
   productCode: string;
   productName: string;
   brand: string;
+  packSize: string;
   quantity: number;
   price: number;
   discount: number;
@@ -35,9 +36,18 @@ const QuotationBuilder = () => {
 
   const [items, setItems] = useState<QuotationItem[]>([]);
   const [transport, setTransport] = useState(0);
-  const [form, setForm] = useState({ productName: "", productCode: "", brand: "", quantity: "", price: "", discount: "", gst: "" });
+  const [form, setForm] = useState({
+    productName: "",
+    productCode: "",
+    brand: "",
+    packSize: "",
+    quantity: "",
+    price: "",
+    discount: "",
+    gst: "",
+  });
   const [filtered, setFiltered] = useState<ProductEntry[]>([]);
-  const allProducts = useMemo(() => getAllProducts(),[]);
+  const allProducts = useMemo(() => getAllProducts(), []);
   const pdfRef = useRef(null);
 
   const handleAdd = () => {
@@ -49,6 +59,7 @@ const QuotationBuilder = () => {
       productCode: form.productCode,
       productName: form.productName,
       brand: form.brand,
+      packSize: form.packSize,
       quantity: parseInt(form.quantity),
       price: parseFloat(form.price),
       discount: parseFloat(form.discount || "0"),
@@ -57,7 +68,16 @@ const QuotationBuilder = () => {
       custom: true,
     };
     setItems([...items, newItem]);
-    setForm({ productName: "", productCode: "", brand: "", quantity: "", price: "", discount: "", gst: "" });
+    setForm({
+      productName: "",
+      productCode: "",
+      brand: "",
+      packSize: "",
+      quantity: "",
+      price: "",
+      discount: "",
+      gst: "",
+    });
   };
 
   const removeItem = (id: number) => setItems(items.filter((item) => item.id !== id));
@@ -112,41 +132,44 @@ const QuotationBuilder = () => {
           <CardContent className="grid grid-cols-1 md:grid-cols-6 gap-4">
             <div className="relative md:col-span-3">
               <Label>Search Product</Label>
-              <Input
-                value={form.productName}
-                onChange={(e) => {
-                  const query = e.target.value.toLowerCase();
-                  const results = allProducts.filter((p) => `${p.productName} ${p.code}`.toLowerCase().includes(query));
-                  setForm({ ...form, productName: query });
-                  setFiltered(results);
-                }}
-              />
-              {form.productName && filtered.length > 0 && (
-                <div className="absolute z-10 bg-white shadow border mt-1 w-full max-h-64 overflow-y-auto text-sm">
-                  {filtered.slice(0, 50).map((product, index) => (
-                    <div
-                      key={index}
-                      className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
-                      onClick={() => {
-                        setForm({
-                          productName: product.productName,
-                          productCode: product.code,
-                          brand: product.brand,
-                          quantity: "",
-                          price: product.price ? product.price.toString() : "",
-                          discount: "",
-                          gst: "",
-                        });
-                        setFiltered([]);
-                      }}
-                    >
-                      <span className="font-medium">{product.productName}</span>{" "}
-                      <span className="text-xs text-muted-foreground">[Code: {product.code}]</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+                <Input
+                  value={form.productName}
+                  onChange={(e) => {
+                    const query = e.target.value.toLowerCase();
+                    const results = allProducts.filter((p) =>
+                      `${p.productName} ${p.code} ${p.packSize}`.toLowerCase().includes(query)
+                    );
+                    setForm({ ...form, productName: e.target.value });
+                    setFiltered(results);
+                  }}
+                />
+                {form.productName && filtered.length > 0 && (
+                  <div className="absolute z-10 bg-white shadow border mt-1 w-full max-h-64 overflow-y-auto text-sm">
+                    {filtered.slice(0, 50).map((product, index) => (
+                      <div
+                        key={index}
+                        className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
+                        onClick={() => {
+                          setForm({
+                            productName: product.productName,
+                            productCode: product.code,
+                            brand: product.brand,
+                            packSize: product.packSize,
+                            quantity: "",
+                            price: product.price ? product.price.toString() : "",
+                            discount: "",
+                            gst: "",
+                          });
+                          setFiltered([]);
+                        }}
+                      >
+                        <span className="font-medium">{product.productName}</span>{" "}
+                        <span className="text-xs text-muted-foreground">[Code: {product.code}] • [Size: {product.packSize}]</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             <div>
               <Label>Brand</Label>
               <Input value={form.brand} onChange={(e) => setForm({ ...form, brand: e.target.value })} />

--- a/app/admin/restock/page.tsx
+++ b/app/admin/restock/page.tsx
@@ -13,6 +13,7 @@ import { getAllProducts, ProductEntry } from "@/lib/get-all-products"
 interface RestockItem {
   id: number
   productName: string
+  code: string
   brand: string
   packSize: string
   quantity: number
@@ -28,26 +29,39 @@ export default function RestockPage() {
   const [items, setItems] = useState<RestockItem[]>([])
   const [form, setForm] = useState({
     productName: "",
+    code: "",
     brand: "",
     packSize: "",
     quantity: "",
     price: "",
+    discount: "",
+    gst: "",
   })
   const [filtered, setFiltered] = useState<ProductEntry[]>([])
-  const allProducts = useMemo(() => getAllProducts(),[]);
+  const allProducts = useMemo(() => getAllProducts(), [])
 
   const handleAdd = () => {
     if (!form.productName || !form.quantity || !form.price) return
     const newItem: RestockItem = {
       id: Date.now(),
       productName: form.productName,
+      code: form.code,
       brand: form.brand,
       packSize: form.packSize,
       quantity: parseInt(form.quantity),
       price: parseFloat(form.price),
     }
     setItems([...items, newItem])
-    setForm({ productName: "", brand: "", packSize: "", quantity: "", price: "" })
+    setForm({
+      productName: "",
+      code: "",
+      brand: "",
+      packSize: "",
+      quantity: "",
+      price: "",
+      discount: "",
+      gst: "",
+    })
   }
 
   const removeItem = (id: number) => {
@@ -92,7 +106,7 @@ export default function RestockPage() {
                   const results = allProducts.filter((p) =>
                     `${p.productName} ${p.code} ${p.packSize}`.toLowerCase().includes(query)
                   )
-                  setForm({ ...form, productName: query })
+                  setForm({ ...form, productName: e.target.value })
                   setFiltered(results)
                 }}
               />
@@ -104,11 +118,14 @@ export default function RestockPage() {
                       className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
                       onClick={() => {
                         setForm({
-                          productName: `${product.productName} (${product.code})`,
+                          productName: product.productName,
+                          code: product.code,
                           brand: product.brand,
                           packSize: product.packSize,
                           quantity: "",
                           price: product.price ? product.price.toString() : "",
+                          discount: "",
+                          gst: "",
                         })
                         setFiltered([])
                       }}


### PR DESCRIPTION
## Summary
- load product catalog once with useMemo for restock and quotation pages
- add search dropdowns filtering by name, code, and pack size
- auto-fill form fields and push selected products to state

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm exec tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6894ee619a44832c9c0db794599914a1