### PR TITLE
feat: add site-wide animated background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -248,3 +248,65 @@
   .animate-mesh, .animate-grid { animation: none !important; }
 }
 
+/* Ensure page can show a fixed full-viewport background */
+html, body { min-height: 100%; }
+
+/* Deep blue base behind the whole page */
+.site-bg{
+  background:
+    radial-gradient(1200px 800px at 50% -10%, #0b3a7e 0%, #0a2c63 35%, #082752 60%, #071f42 100%);
+}
+
+/* Animated soft blobs + sliding grid */
+.fx-mesh{
+  background:
+    radial-gradient(1000px 400px at 80% -10%, rgba(20,184,166,.12), transparent 60%),
+    radial-gradient(800px 300px at -10% 20%, rgba(14,165,233,.12), transparent 60%),
+    radial-gradient(700px 280px at 40% 90%, rgba(14,165,233,.08), transparent 60%);
+  will-change: transform;
+}
+.fx-grid{
+  background:
+    linear-gradient(to right, rgba(226,232,240,.38) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(226,232,240,.38) 1px, transparent 1px);
+  background-size: 80px 80px, 80px 80px;
+  will-change: background-position;
+}
+
+/* Keyframes */
+@keyframes mesh {
+  0% { transform: translate3d(0,0,0) scale(1); }
+  50% { transform: translate3d(0,-2%,0) scale(1.02); }
+  100% { transform: translate3d(0,0,0) scale(1); }
+}
+@keyframes gridSlide {
+  from { background-position: 0 0, 0 0; }
+  to   { background-position: 80px 80px, 80px 80px; }
+}
+
+/* Animators */
+.animate-mesh { animation: mesh 22s linear infinite; }
+.animate-grid { animation: gridSlide 24s linear infinite; }
+
+/* Fallback: if the FX container didn't render, paint on body */
+body.fx-fallback::before,
+body.fx-fallback::after{
+  content:""; position: fixed; inset: 0; pointer-events: none; z-index: -1;
+}
+body.fx-fallback::before {
+  background:
+    radial-gradient(1200px 800px at 50% -10%, #0b3a7e 0%, #0a2c63 35%, #082752 60%, #071f42 100%);
+}
+body.fx-fallback::after  {
+  background:
+    linear-gradient(to right, rgba(226,232,240,.38) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(226,232,240,.38) 1px, transparent 1px);
+  background-size: 80px 80px, 80px 80px;
+  animation: gridSlide 24s linear infinite;
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-mesh, .animate-grid,
+  body.fx-fallback::after { animation: none !important; }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 // app/page.tsx (or wherever your homepage lives)
+import { useEffect } from "react";
 import { ParallaxBackground } from "@/components/parallax-background";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -8,12 +11,21 @@ import { Shield, Truck, Award, Globe, Zap, ChevronRight } from "lucide-react";
 
 
 export default function HomePage() {
+  useEffect(() => {
+    if (!document.getElementById("fx-bg")) {
+      document.body.classList.add("fx-fallback")
+    } else {
+      document.body.classList.remove("fx-fallback")
+    }
+  }, [])
+
   return (
     <div className="min-h-screen relative overflow-hidden">
-      <div className="fixed inset-0 -z-10 pointer-events-none">
+      {/* FX BG (single instance) */}
+      <div id="fx-bg" className="fixed inset-0 -z-10 pointer-events-none">
         <div className="site-bg absolute inset-0" />
         <div className="fx-mesh absolute inset-0 animate-mesh opacity-60" />
-        <div className="fx-grid absolute inset-0 animate-grid opacity-35 [mask-image:linear-gradient(to_bottom,transparent,black_10%,black_85%,transparent)]" />
+        <div className="fx-grid absolute inset-0 animate-grid opacity-35 [mask-image:linear-gradient(to_bottom,transparent,black_10%,black_85%,transparent)] [-webkit-mask-image:linear-gradient(to_bottom,transparent,black_10%,black_85%,transparent)]" />
       </div>
 
       {/* Hero Section */}


### PR DESCRIPTION
## Summary
- mount global animated FX layer on homepage with fallback detection
- append blue mesh and grid animations plus body fallback styles

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_689a62dfcdbc832c8476bb27dcd28c63