### PR TITLE
feat: extend site background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,21 +18,17 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      {/* IMPORTANT: body must be relative so the background layer can sit behind it */}
-      <body className={`relative min-h-screen ${inter.className}`}>
-        {/* 🔵 Global animated blue background for the entire site */}
-        <div id="fx-bg" className="fixed inset-0 z-0 pointer-events-none">
-          <div className="site-bg absolute inset-0" />
-          <div className="fx-mesh absolute inset-0 animate-mesh opacity-60" />
-          <div className="fx-grid absolute inset-0 animate-grid opacity-35 [mask-image:linear-gradient(to_bottom,transparent,black_10%,black_85%,transparent)] [-webkit-mask-image:linear-gradient(to_bottom,transparent,black_10%,black_85%,transparent)]" />
+      <body className={`${inter.className} site-bg`}>
+        {/* Global animated FX background (site-wide) */}
+        <div aria-hidden className="pointer-events-none fixed inset-0 -z-10">
+          <div className="fx-mesh absolute -inset-40 opacity-60 animate-mesh" />
+          <div className="fx-grid absolute inset-0 opacity-35 animate-grid" />
         </div>
 
         {/* App content ABOVE the background */}
-        <div className="relative z-10">
-          <ClientProviders>
-            <SiteShell>{children}</SiteShell>
-          </ClientProviders>
-        </div>
+        <ClientProviders>
+          <SiteShell>{children}</SiteShell>
+        </ClientProviders>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ import {
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-transparent">
       {/* ===== HERO ===== */}
       <section className="relative h-screen flex items-center justify-center overflow-hidden">
         <ParallaxBackground />

--- a/components/parallax-background.tsx
+++ b/components/parallax-background.tsx
@@ -20,7 +20,7 @@ export function ParallaxBackground() {
   }, [])
 
   return (
-    <div className="absolute inset-0 overflow-hidden">
+    <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden">
       <div ref={containerRef} className="absolute inset-0 w-full h-[120%]">
         {/* Laboratory Grid Background */}
         <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900">

--- a/components/site-shell.tsx
+++ b/components/site-shell.tsx
@@ -1,16 +1,14 @@
-"use client"
+"use client";
 
-import { usePathname } from "next/navigation"
-import { Header } from "@/components/header"
-import { Footer } from "@/components/footer"
+import { Header } from "@/components/header";
+import { Footer } from "@/components/footer";
 
 export function SiteShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
-      {/* header */}
-      {/* if Header has bg-white, keep it (headers are fine), but main must be transparent */}
+      <Header />
       <main className="flex-1 bg-transparent">{children}</main>
-      {/* footer */}
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- apply global site-wide blue gradient and animated FX
- keep site shell transparent and include header/footer
- constrain parallax background within hero and ensure transparent page sections

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689addb78bf0832cadf559c7d598d32f