### PR TITLE
feat: add foreground fx overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 /* ---------------- Base Theme Tokens ---------------- */
 @layer base {
   :root {
-    --background: 220 20% 97%; /* Soft Silver #F2F4F6 */
+    --background: 0 0% 100%; /* White base */
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -211,25 +211,21 @@
 /* Ensure page can show a fixed full-viewport background */
 html, body { min-height: 100%; }
 
-/* Deep blue base behind the whole page */
-.site-bg{
-  background:
-    radial-gradient(1200px 800px at 50% -10%, #0b3a7e 0%, #0a2c63 35%, #082752 60%, #071f42 100%);
-}
-
 /* Animated soft blobs + sliding grid */
-.fx-mesh{
+.fx-mesh {
   background:
-    radial-gradient(1000px 400px at 80% -10%, rgba(20,184,166,.12), transparent 60%),
-    radial-gradient(800px 300px at -10% 20%, rgba(14,165,233,.12), transparent 60%),
-    radial-gradient(700px 280px at 40% 90%, rgba(14,165,233,.08), transparent 60%);
+    radial-gradient(1000px 400px at 80% -10%, rgba(20,184,166,.35), transparent 60%),
+    radial-gradient(800px 300px at -10% 20%, rgba(14,165,233,.30), transparent 60%),
+    radial-gradient(700px 280px at 40% 90%, rgba(14,165,233,.18), transparent 60%);
+  animation: mesh 22s linear infinite;
   will-change: transform;
 }
-.fx-grid{
+.fx-grid {
   background:
-    linear-gradient(to right, rgba(226,232,240,.38) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(226,232,240,.38) 1px, transparent 1px);
+    linear-gradient(to right, rgba(2,6,23,.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(2,6,23,.08) 1px, transparent 1px);
   background-size: 80px 80px, 80px 80px;
+  animation: gridSlide 24s linear infinite;
   will-change: background-position;
 }
 
@@ -267,6 +263,6 @@ body.fx-fallback::after  {
 
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .animate-mesh, .animate-grid,
+  .fx-mesh, .fx-grid, .animate-mesh, .animate-grid,
   body.fx-fallback::after { animation: none !important; }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,17 +18,21 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} site-bg`}>
-        {/* Global animated FX background (site-wide) */}
-        <div aria-hidden className="pointer-events-none fixed inset-0 -z-10">
-          <div className="fx-mesh absolute -inset-40 opacity-60 animate-mesh" />
-          <div className="fx-grid absolute inset-0 opacity-35 animate-grid" />
-        </div>
-
-        {/* App content ABOVE the background */}
+      <body className={`${inter.className} bg-white`}>
         <ClientProviders>
           <SiteShell>{children}</SiteShell>
         </ClientProviders>
+
+        {/* Global animated FX overlay (site-wide) */}
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 z-[60] mix-blend-normal"
+        >
+          {/* Subtle animated mesh */}
+          <div className="fx-mesh absolute -inset-40 opacity-[0.09] animate-mesh" />
+          {/* Sliding grid */}
+          <div className="fx-grid absolute inset-0 opacity-[0.06] animate-grid" />
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- layer subtle animated mesh and grid overlay above all content with pointer-events disabled for full site
- switch to white base background and update fx styles and animations

## Testing
- `pnpm lint` *(fails: recommends adding Next.js ESLint plugin)*
- `pnpm build` *(fails: could not fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_689aeadbb9b8832c8c925273091619cf