### PR TITLE
Remove duplicate admin headers

### DIFF
--- a/app/admin/quotation/page.tsx
+++ b/app/admin/quotation/page.tsx
@@ -449,13 +449,7 @@ useEffect(() => {
   }
 
   return (
-    <>
-      <div className="container mx-auto px-4 py-8">
-        <div className="mb-8 text-center">
-          <h1 className="text-3xl font-bold">Chemical Corporation, Ludhiana</h1>
-          <p className="text-gray-500">Quotation Builder</p>
-        </div>
-
+    <div className="container mx-auto px-4 py-8">
         {/* Client Details */}
         <Card className="mb-6">
           <CardHeader><CardTitle>Client Details</CardTitle></CardHeader>
@@ -587,8 +581,7 @@ useEffect(() => {
           </Card>
         )}
       </div>
-    </>
-  )
+  );
 }
 
 export default function QuotationBuilderPage() {
@@ -596,5 +589,5 @@ export default function QuotationBuilderPage() {
     <Suspense fallback={<div className="p-4 text-sm text-muted-foreground">Loading quotation…</div>}>
       <QuotationBuilderInner />
     </Suspense>
-  )
+  );
 }

--- a/app/admin/restock/page.tsx
+++ b/app/admin/restock/page.tsx
@@ -92,13 +92,7 @@ export default function RestockPage() {
   };
 
   return (
-    <>
-      <div className="container mx-auto px-4 py-8">
-        <div className="mb-8 text-center">
-          <h1 className="text-3xl font-bold">Chemical Corporation, Ludhiana</h1>
-          <p className="text-gray-500">Restock Dashboard</p>
-        </div>
-
+    <div className="container mx-auto px-4 py-8">
         <Card className="mb-6">
           <CardHeader>
             <CardTitle>Add Product to Restock</CardTitle>
@@ -210,6 +204,5 @@ export default function RestockPage() {
           </Card>
         )}
       </div>
-    </>
   );
 }


### PR DESCRIPTION
## Summary
- drop in-page headers from quotation and restock admin pages so layout header renders once

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689b26735dcc832c9597f7ba2bb7b840