### PR TITLE
feat: add order approval workflow

### DIFF
--- a/app/admin/client-approvals/page.tsx
+++ b/app/admin/client-approvals/page.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { createClient } from "@supabase/supabase-js"
+import { useAuth } from "@/app/context/auth-context"
+import AccessDenied from "@/components/access-denied"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/hooks/use-toast"
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+)
+
+export default function ClientApprovalsPage() {
+  const { role, loading } = useAuth()
+  const { toast } = useToast()
+  const [profiles, setProfiles] = useState<any[]>([])
+
+  useEffect(() => {
+    if (role === "admin") load()
+  }, [role])
+
+  async function load() {
+    const { data } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("status", "pending")
+      .order("created_at", { ascending: true })
+    setProfiles(data || [])
+  }
+
+  async function approve(id: string) {
+    await supabase
+      .from("profiles")
+      .update({ status: "approved", role: "client" })
+      .eq("id", id)
+    toast({ title: "Client approved" })
+    load()
+  }
+
+  async function reject(id: string) {
+    await supabase
+      .from("profiles")
+      .update({ status: "rejected", role: "rejected" })
+      .eq("id", id)
+    toast({ title: "Client rejected" })
+    load()
+  }
+
+  if (!loading && role !== "admin") return <AccessDenied />
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-4">Client Approvals</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Company</TableHead>
+            <TableHead>Phone</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {profiles.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>{p.full_name || "—"}</TableCell>
+              <TableCell>{p.email}</TableCell>
+              <TableCell>{p.company_name || p.company || "—"}</TableCell>
+              <TableCell>{p.phone || p.contact_number || "—"}</TableCell>
+              <TableCell className="text-right space-x-2">
+                <Button size="sm" onClick={() => approve(p.id)}>
+                  Approve
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => reject(p.id)}>
+                  Reject
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+          {profiles.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} className="text-center text-sm py-6 text-muted-foreground">
+                No pending profiles
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/admin/order-approvals/ApproveDialog.tsx
+++ b/app/admin/order-approvals/ApproveDialog.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  order: any | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onApproved: () => void
+}
+
+export default function ApproveDialog({ order, open, onOpenChange, onApproved }: Props) {
+  const [loading, setLoading] = useState(false)
+  if (!order) return null
+
+  const items = Array.isArray(order.items) ? order.items : []
+
+  const approve = async () => {
+    setLoading(true)
+    const res = await fetch(`/api/admin/orders/${order.id}/approve`, { method: "POST" })
+    setLoading(false)
+    if (res.ok) onApproved()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Approve Order {order.id}</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto">
+          {items.length > 0 && (
+            <Table className="mb-4">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Item</TableHead>
+                  <TableHead>Qty</TableHead>
+                  <TableHead>Price</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((it: any, idx: number) => (
+                  <TableRow key={idx}>
+                    <TableCell>{it.name}</TableCell>
+                    <TableCell>{it.qty}</TableCell>
+                    <TableCell>₹{Number(it.price).toFixed(2)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          <div className="font-medium text-right">Total: ₹{Number(order.total).toFixed(2)}</div>
+        </div>
+        <DialogFooter>
+          <Button onClick={approve} disabled={loading}>
+            {loading ? "Approving..." : "Approve"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/admin/order-approvals/RejectDialog.tsx
+++ b/app/admin/order-approvals/RejectDialog.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  order: any | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRejected: () => void
+}
+
+export default function RejectDialog({ order, open, onOpenChange, onRejected }: Props) {
+  const [note, setNote] = useState("")
+  const [loading, setLoading] = useState(false)
+  if (!order) return null
+
+  const reject = async () => {
+    setLoading(true)
+    const res = await fetch(`/api/admin/orders/${order.id}/reject`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ note }),
+    })
+    setLoading(false)
+    if (res.ok) onRejected()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reject Order {order.id}</DialogTitle>
+        </DialogHeader>
+        <Textarea
+          className="mb-4"
+          placeholder="Reason (optional)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <DialogFooter>
+          <Button variant="destructive" onClick={reject} disabled={loading}>
+            {loading ? "Rejecting..." : "Reject"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/admin/order-approvals/page.tsx
+++ b/app/admin/order-approvals/page.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { createClient } from "@supabase/supabase-js"
+import { useAuth } from "@/app/context/auth-context"
+import AccessDenied from "@/components/access-denied"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import ApproveDialog from "./ApproveDialog"
+import RejectDialog from "./RejectDialog"
+import { useToast } from "@/hooks/use-toast"
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+)
+
+export default function OrderApprovalsPage() {
+  const { role, loading } = useAuth()
+  const { toast } = useToast()
+  const [orders, setOrders] = useState<any[]>([])
+  const [approveOrder, setApproveOrder] = useState<any | null>(null)
+  const [rejectOrder, setRejectOrder] = useState<any | null>(null)
+
+  useEffect(() => {
+    if (role === "admin") load()
+  }, [role])
+
+  async function load() {
+    const { data } = await supabase
+      .from("orders")
+      .select("*")
+      .eq("status", "awaiting_approval")
+      .order("created_at", { ascending: false })
+    setOrders(data || [])
+  }
+
+  if (!loading && role !== "admin") return <AccessDenied />
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-semibold mb-4">Order Approvals</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Created</TableHead>
+            <TableHead>Order ID</TableHead>
+            <TableHead>Customer</TableHead>
+            <TableHead>Total</TableHead>
+            <TableHead>Items</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map((o) => (
+            <TableRow key={o.id}>
+              <TableCell>{new Date(o.created_at).toLocaleDateString()}</TableCell>
+              <TableCell>{o.id}</TableCell>
+              <TableCell>{o.company_name || o.email}</TableCell>
+              <TableCell>₹{Number(o.total).toFixed(2)}</TableCell>
+              <TableCell>{Array.isArray(o.items) ? o.items.length : 0}</TableCell>
+              <TableCell>{o.status}</TableCell>
+              <TableCell className="text-right space-x-2">
+                <Button size="sm" onClick={() => setApproveOrder(o)}>
+                  Approve
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => setRejectOrder(o)}>
+                  Reject
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+          {orders.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center text-sm py-6 text-muted-foreground">
+                No orders awaiting approval
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+
+      <ApproveDialog
+        order={approveOrder}
+        open={Boolean(approveOrder)}
+        onOpenChange={(open) => !open && setApproveOrder(null)}
+        onApproved={() => {
+          toast({ title: "Order approved" })
+          setApproveOrder(null)
+          load()
+        }}
+      />
+      <RejectDialog
+        order={rejectOrder}
+        open={Boolean(rejectOrder)}
+        onOpenChange={(open) => !open && setRejectOrder(null)}
+        onRejected={() => {
+          toast({ title: "Order rejected" })
+          setRejectOrder(null)
+          load()
+        }}
+      />
+    </div>
+  )
+}

--- a/app/api/admin/orders/[id]/approve/route.ts
+++ b/app/api/admin/orders/[id]/approve/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server"
+import { getServerSupabase } from "@/lib/supabase/server-client"
+import { getSupabaseAdmin } from "@/lib/supabase/admin"
+import { createPaymentLink } from "@/lib/payments"
+import { sendOrderApprovedEmail } from "@/lib/mail"
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const server = getServerSupabase()
+  const admin = getSupabaseAdmin()
+  if (!server || !admin) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 })
+  }
+
+  const {
+    data: { user },
+    error: userErr,
+  } = await server.auth.getUser()
+  if (userErr || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: profile } = await server
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single()
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { data: order, error: orderErr } = await admin
+    .from("orders")
+    .select("*")
+    .eq("id", params.id)
+    .single()
+  if (orderErr || !order) {
+    return NextResponse.json({ error: orderErr?.message || "Order not found" }, { status: 404 })
+  }
+
+  const payment = await createPaymentLink(order)
+
+  const { error: updErr } = await admin
+    .from("orders")
+    .update({
+      status: "approved",
+      approved_at: new Date().toISOString(),
+      approved_by: user.id,
+      payment_provider: payment?.provider || null,
+      payment_intent_id: payment?.id || null,
+    })
+    .eq("id", params.id)
+  if (updErr) {
+    return NextResponse.json({ error: updErr.message }, { status: 500 })
+  }
+
+  // approve profile if pending
+  try {
+    await admin
+      .from("profiles")
+      .update({ status: "approved", role: "client" })
+      .eq("email", order.email)
+  } catch (e) {
+    console.warn("[orders] profile approve failed", e)
+  }
+
+  await sendOrderApprovedEmail(order.email, order.id, payment?.url || undefined)
+
+  return NextResponse.json({ status: "approved", paymentLink: payment?.url || null })
+}

--- a/app/api/admin/orders/[id]/reject/route.ts
+++ b/app/api/admin/orders/[id]/reject/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server"
+import { getServerSupabase } from "@/lib/supabase/server-client"
+import { getSupabaseAdmin } from "@/lib/supabase/admin"
+import { sendOrderRejectedEmail } from "@/lib/mail"
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const server = getServerSupabase()
+  const admin = getSupabaseAdmin()
+  if (!server || !admin) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 })
+  }
+
+  const {
+    data: { user },
+    error: userErr,
+  } = await server.auth.getUser()
+  if (userErr || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: profile } = await server
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single()
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const body = await req.json().catch(() => ({}))
+  const note: string | null = body?.note || null
+
+  const { data: order, error: orderErr } = await admin
+    .from("orders")
+    .select("email")
+    .eq("id", params.id)
+    .single()
+  if (orderErr || !order) {
+    return NextResponse.json({ error: orderErr?.message || "Order not found" }, { status: 404 })
+  }
+
+  const { error: updErr } = await admin
+    .from("orders")
+    .update({
+      status: "rejected",
+      approval_note: note,
+      approved_at: new Date().toISOString(),
+      approved_by: user.id,
+    })
+    .eq("id", params.id)
+  if (updErr) {
+    return NextResponse.json({ error: updErr.message }, { status: 500 })
+  }
+
+  await sendOrderRejectedEmail(order.email, params.id, note || undefined)
+  return NextResponse.json({ status: "rejected" })
+}

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,0 +1,92 @@
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+import { NextResponse } from "next/server"
+import { getServerSupabase } from "@/lib/supabase/server-client"
+import { getSupabaseAdmin } from "@/lib/supabase/admin"
+import { CreateOrderSchema } from "@/lib/validation/order"
+import { sendAdminNewOrderEmail, sendOrderReceivedEmail } from "@/lib/mail"
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null)
+  const parse = CreateOrderSchema.safeParse(json)
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 })
+  }
+
+  const server = getServerSupabase()
+  const admin = getSupabaseAdmin()
+  if (!server || !admin) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 })
+  }
+
+  const {
+    email,
+    phone,
+    company_name,
+    gst,
+    shipping_address,
+    billing_address,
+    items,
+    subtotal,
+    tax,
+    shipping,
+    discount,
+    total,
+  } = parse.data
+
+  const {
+    data: { user },
+  } = await server.auth.getUser()
+  const userId = user?.id || null
+
+  const profilePayload: any = {
+    email,
+    company_name: company_name || null,
+    gst: gst || null,
+    phone: phone || null,
+    status: "pending",
+  }
+  if (userId) profilePayload.id = userId
+
+  // Upsert profile by email/id
+  try {
+    await admin.from("profiles").upsert(profilePayload, { onConflict: userId ? "id" : "email" })
+  } catch (e) {
+    console.warn("[orders] profile upsert failed", e)
+  }
+
+  const orderPayload = {
+    user_id: userId,
+    email,
+    phone: phone || null,
+    company_name: company_name || null,
+    gst: gst || null,
+    shipping_address: shipping_address || null,
+    billing_address: billing_address || null,
+    items,
+    subtotal,
+    tax,
+    shipping,
+    discount: discount ?? 0,
+    total,
+    status: "awaiting_approval" as const,
+  }
+
+  const { data: order, error } = await admin
+    .from("orders")
+    .insert(orderPayload)
+    .select("id, status")
+    .single()
+
+  if (error || !order) {
+    return NextResponse.json({ error: error?.message || "Order creation failed" }, { status: 500 })
+  }
+
+  await Promise.all([
+    sendAdminNewOrderEmail(order.id, email),
+    sendOrderReceivedEmail(email, order.id),
+  ])
+
+  return NextResponse.json({ orderId: order.id, status: order.status }, { status: 201 })
+}

--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -1,0 +1,24 @@
+export async function sendAdminNewOrderEmail(orderId: string, email: string) {
+  log(`[mail] admin notified of new order ${orderId} from ${email}`)
+}
+
+export async function sendOrderReceivedEmail(email: string, orderId: string) {
+  log(`[mail] user ${email} received order confirmation for ${orderId}`)
+}
+
+export async function sendOrderApprovedEmail(email: string, orderId: string, paymentLink?: string | null) {
+  log(`[mail] order ${orderId} for ${email} approved${paymentLink ? ` with link ${paymentLink}` : ""}`)
+}
+
+export async function sendOrderRejectedEmail(email: string, orderId: string, note?: string) {
+  log(`[mail] order ${orderId} for ${email} rejected${note ? `: ${note}` : ""}`)
+}
+
+function log(message: string) {
+  if (!process.env.RESEND_API_KEY) {
+    console.warn(message)
+    return
+  }
+  // Real email implementation would go here
+  console.log(message)
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,12 @@
+export type PaymentLink = { id: string; url: string; provider?: string }
+
+export async function createPaymentLink(_order: any): Promise<PaymentLink | null> {
+  const id = process.env.RAZORPAY_KEY_ID
+  const secret = process.env.RAZORPAY_KEY_SECRET
+  if (!id || !secret) {
+    console.warn("[payments] Razorpay env missing, not creating link")
+    return null
+  }
+  // Placeholder implementation; integrate with provider later
+  return null
+}

--- a/lib/validation/order.ts
+++ b/lib/validation/order.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+
+export const OrderItemSchema = z.object({
+  sku: z.string().optional(),
+  name: z.string(),
+  qty: z.number().int().positive(),
+  price: z.number().nonnegative(),
+})
+
+export const CreateOrderSchema = z.object({
+  email: z.string().email(),
+  phone: z.string().optional(),
+  company_name: z.string().optional(),
+  gst: z.string().optional(),
+  shipping_address: z.any().optional(),
+  billing_address: z.any().optional(),
+  items: z.array(OrderItemSchema).nonempty(),
+  subtotal: z.number(),
+  tax: z.number(),
+  shipping: z.number(),
+  discount: z.number().optional().default(0),
+  total: z.number(),
+})
+
+export type CreateOrderInput = z.infer<typeof CreateOrderSchema>
+export type OrderItemInput = z.infer<typeof OrderItemSchema>


### PR DESCRIPTION
## Summary
- add zod order schema and email/payment stubs
- implement public order creation endpoint with awaiting_approval status
- add admin approve/reject APIs and dashboard pages for orders and clients

## Testing
- `pnpm lint` *(fails: Next.js lint requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689cb1184024832c9aa4c2bfa034cdee