### PR TITLE
feat: add omsons brand to dropdown

### DIFF
--- a/components/header-client.tsx
+++ b/components/header-client.tsx
@@ -54,6 +54,12 @@ export function ClientHeaderBrandDropdown() {
             HiMedia
           </Link>
         </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href="/brand/omsons" className="flex items-center">
+            <Image src="/images/brands/omsons/logo.png" alt="Omsons Glassware" width={20} height={20} className="mr-2" />
+            Omsons Glassware
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link href="/products/laboratory-supplies" className="text-blue-600 font-medium">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -147,6 +147,12 @@ export function Header() {
                     HiMedia
                   </Link>
                 </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/brand/omsons" className="flex items-center">
+                    <Image src="/images/brands/omsons/logo.png" alt="Omsons Glassware" width={20} height={20} className="mr-2" />
+                    Omsons Glassware
+                  </Link>
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem asChild>
                   <Link href="/products/laboratory-supplies" className="text-blue-600 font-medium">


### PR DESCRIPTION
## Summary
- add Omsons Glassware to header brand dropdown (server and client headers)

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689ee78f43d0832c8e2378b6c1c85e52