### PR TITLE
Handle POR prices without coercion

### DIFF
--- a/app/products/search/page.tsx
+++ b/app/products/search/page.tsx
@@ -28,6 +28,7 @@ const norm = (s: any) => (s == null ? "" : String(s)).toLowerCase()
 const stripNonAlnum = (s: any) => String(s ?? "").toLowerCase().replace(/[^a-z0-9]/g, "")
 const inr = (n: number) => n.toLocaleString("en-IN", { style: "currency", currency: "INR" })
 const isNum = (v: any) => typeof v === "number" && Number.isFinite(v)
+const isPOR = (v: any) => /^por$/i.test(String(v ?? "").trim())
 const toNum = (v: any): number | null => {
   if (typeof v === "number") return Number.isFinite(v) ? v : null
   if (v == null) return null
@@ -364,14 +365,19 @@ function SearchResults() {
       return
     }
     try {
+      if (isPOR(product.price)) {
+        toast({ title: "Price on Request", description: "Price on Request • POR" })
+        return
+      }
       const priceNum = toNum(product.price)
       if (priceNum == null || priceNum <= 0) {
         toast({ title: "Price on request", description: "This item does not have a numeric price.", variant: "default" })
+        return
       }
       addItem({
         id: product.id || product.code || `${product.source}-${Math.random().toString(36).slice(2, 10)}`,
         name: product.name || product.product || product.title,
-        price: priceNum || 0,
+        price: priceNum,
         brand: product.source,
         category: product.category,
       })
@@ -417,7 +423,11 @@ function SearchResults() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {paginatedResults.map((product) => {
                 const priceNum = toNum(product.price)
-                const priceDisplay = priceNum != null && priceNum > 0 ? inr(priceNum) : "Price on request"
+                const priceDisplay = isPOR(product.price)
+                  ? "POR"
+                  : priceNum != null && priceNum > 0
+                    ? inr(priceNum)
+                    : "Price on request"
 
                 const specs: {label: string, value: any}[] = Array.isArray(product.specs)
                   ? product.specs.map((s: any) =>

--- a/components/quali-product-grid.tsx
+++ b/components/quali-product-grid.tsx
@@ -16,7 +16,8 @@ type QualigensProduct = {
   category: string
   packSize: string
   material: string
-  price: number
+  /** Price may be numeric or the literal string "POR" */
+  price: number | string
   purity: string
   brand: string
   hsn: string
@@ -32,6 +33,8 @@ export function QualiProductGrid({ products }: QualiProductGridProps) {
   const productsPerPage = 24
   const { addItem } = useCart()
   const { toast } = useToast()
+
+  const isPOR = (v: any) => /^por$/i.test(String(v ?? "").trim())
 
   const filteredProducts = useMemo(() => {
     if (!products || !Array.isArray(products)) return []
@@ -50,10 +53,15 @@ export function QualiProductGrid({ products }: QualiProductGridProps) {
   const displayedProducts = filteredProducts.slice(startIndex, startIndex + productsPerPage)
 
   const handleAddToCart = (product: QualigensProduct) => {
+    if (isPOR(product.price) || Number(product.price) <= 0) {
+      toast({ title: "Price on Request", description: "Price on Request • POR" })
+      return
+    }
+    const priceNum = typeof product.price === "number" ? product.price : Number(String(product.price).replace(/[^\d.]/g, "")) || 0
     const cartItem = {
       id: product.id,
       name: product.name,
-      price: product.price,
+      price: priceNum,
       brand: "Qualigens",
       category: product.category,
       packSize: product.packSize,
@@ -112,7 +120,9 @@ export function QualiProductGrid({ products }: QualiProductGridProps) {
                 <p>
                   <span className="font-medium">HSN:</span> {product.hsn}
                 </p>
-                <p className="font-semibold text-blue-600">₹{product.price.toLocaleString()}</p>
+                <p className="font-semibold text-blue-600">
+                  {isPOR(product.price) ? "POR" : `₹${Number(product.price).toLocaleString()}`}
+                </p>
               </div>
             </CardContent>
             <CardFooter>

--- a/lib/qualigens-products.ts
+++ b/lib/qualigens-products.ts
@@ -4,7 +4,8 @@ export interface QualigensProduct {
   name: string
   packSize: string
   material: string
-  price: number
+  /** Raw price value – may be numeric or the literal string "POR" */
+  price: number | string
   hsn: string
   category?: string
   purity?: string
@@ -31,9 +32,11 @@ export const qualigensProducts: QualigensProduct[] = raw.map((item) => {
   const price =
     typeof priceValue === "number"
       ? priceValue
-      : typeof priceValue === "string" && /^\d/.test(priceValue)
-        ? Number(priceValue)
-        : 0
+      : typeof priceValue === "string" && /^por$/i.test(priceValue.trim())
+        ? "POR"
+        : typeof priceValue === "string" && /^\d/.test(priceValue)
+          ? Number(priceValue.replace(/[^\d.]/g, ""))
+          : 0
   const hsn = item["HSN Code"] || ""
 
   return {


### PR DESCRIPTION
## Summary
- Preserve "POR" prices in Qualigens catalog instead of coercing to 0
- Show POR in Qualigens product grid and prevent adding to cart
- Display POR on search results and block cart adds for POR items

## Testing
- `pnpm lint` *(fails: requires ESLint setup)*
- `pnpm build` *(fails: Supabase URL/Anon Key missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f1240a0d0832c83ec30745ed57519