### PR TITLE
Fix: robust /product/[slug] matching for all brands (brand+name(+pack) or code); remove window usage from SEO; static imports; no images on detail page

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -15,7 +15,6 @@ function packFrom(product: any) {
     product.grade
   );
 }
-
 function codeFrom(product: any) {
   return first(
     product.code,
@@ -27,17 +26,16 @@ function codeFrom(product: any) {
     product.itemCode
   );
 }
-
 function brandFrom(product: any, group?: any) {
   return first(
     product.brand,
     group?.brand,
+    group?.product,
     product.vendor,
     product.mfg,
-    /borosil/i.test(JSON.stringify(product)) ? "Borosil" : ""
+    /borosil/i.test(JSON.stringify(product)) ? "Borosil" : "",
   );
 }
-
 function nameFrom(product: any, group?: any) {
   return first(
     product.productName,
@@ -47,10 +45,9 @@ function nameFrom(product: any, group?: any) {
     product.product
   );
 }
-
 function normalizePrice(p: any) {
   if (p === undefined || p === null) return undefined;
-  if (typeof p === "number") return p;
+  if (typeof p === "number") return Number.isFinite(p) ? p : undefined;
   const txt = String(p).trim().toUpperCase();
   if (txt === "POR" || txt === "P.O.R" || txt === "P O R") return undefined;
   const num = parseFloat(String(p).replace(/[^\d.]/g, ""));
@@ -64,49 +61,36 @@ export type ProductSEO = {
   jsonLd: Record<string, any>;
 };
 
-/**
- * Optionally pass canonicalUrl if you have it in the page (recommended).
- */
-export function getProductSEO(
-  product: any,
-  group?: any,
-  canonicalUrl?: string
-): ProductSEO {
+export function getProductSEO(product: any, group?: any, canonicalUrl?: string): ProductSEO {
   const brand = brandFrom(product, group);
   const name  = nameFrom(product, group);
   const pack  = packFrom(product);
   const code  = codeFrom(product);
 
-  const titleParts = [brand, name, pack].filter(Boolean).join(" ").trim();
+  const titleParts = [brand, name, pack].filter(Boolean).join(" ");
   const codeSuffix = code ? ` – ${code}` : "";
-  const baseTitle = titleParts
-    ? `${titleParts}${codeSuffix}`
-    : "Product";
-
-  const title = `${baseTitle} | Buy Online – Chemical Corporation`;
+  const title = `${titleParts}${codeSuffix} | Buy Online – Chemical Corporation`;
 
   const h1 = `${[brand, name].filter(Boolean).join(" ")}${pack ? ` – ${pack}` : ""}${code ? ` (Code: ${code})` : ""}`;
 
-  const hsn = first(product.hsn, product.hsnCode);
-  const cas = first(product.cas, product.casNo, product.cas_number);
+  const hsn = first(product.hsn, product.hsnCode, product["HSN Code"]);
+  const cas = first(product.cas, product.casNo, product.cas_number, product["CAS No"]);
 
   const description = `Buy ${[brand, name, pack].filter(Boolean).join(" ")} online in India. Genuine ${
     brand || "laboratory"
   } product${code ? ` (Code: ${code})` : ""}${hsn ? `, HSN ${hsn}` : ""}${cas ? `, CAS ${cas}` : ""}. Discount auto-applies in cart. Fast delivery.`;
 
-  // --- JSON-LD (Product) ---
-  const price = normalizePrice(product.price);
+  const price = normalizePrice((product as any).price ?? (product as any).Price ?? (product as any).rate ?? (product as any).price_inr);
   const offers: Record<string, any> = {
     "@type": "Offer",
     priceCurrency: "INR",
-    availability: "https://schema.org/InStock",
-    url: canonicalUrl, // preferred; can be undefined if you don't pass it
-    // itemCondition: "https://schema.org/NewCondition", // optional
+    availability: "http://schema.org/InStock",
   };
   if (price !== undefined) offers.price = price;
+  if (canonicalUrl) offers.url = canonicalUrl;
 
   const jsonLd: Record<string, any> = {
-    "@context": "https://schema.org",
+    "@context": "http://schema.org",
     "@type": "Product",
     name: [brand, name, pack].filter(Boolean).join(" "),
     brand: brand ? { "@type": "Brand", name: brand } : undefined,


### PR DESCRIPTION
## Summary
- handle brand/name/pack/code permutations so `/product/[slug]` works for Whatman, Borosil, Rankem, HiMedia, Omsons, Avarice and Qualigens
- simplify product SEO helper and accept optional canonical URL without touching `window`

## Testing
- `npm run build` *(fails: Supabase URL and/or Anon Key are missing)*
- `npm start` *(fails: no .next/prerender-manifest.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ae8ac4d0832c9dc5ca74ca03cb7a