### PR TITLE
Add diagnostics for product page

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  console.error("[global] client error:", error);
+  return (
+    <html>
+      <body>
+        <div className="container mx-auto px-6 py-16">
+          <h1 className="text-2xl font-bold mb-2">App Error</h1>
+          <pre className="text-xs bg-red-50 border border-red-200 p-3 rounded overflow-auto">
+            {String(error?.stack || error?.message || error)}
+          </pre>
+          <button
+            onClick={() => reset()}
+            className="mt-4 px-4 py-2 rounded border border-slate-300 hover:bg-slate-50"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/product/[slug]/error.tsx
+++ b/app/product/[slug]/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  console.error("[product/[slug]] client error:", error);
+  return (
+    <div className="container mx-auto px-6 py-16">
+      <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+      <pre className="text-xs bg-red-50 border border-red-200 p-3 rounded overflow-auto">
+        {String(error?.stack || error?.message || error)}
+      </pre>
+      <button
+        onClick={() => reset()}
+        className="mt-4 px-4 py-2 rounded border border-slate-300 hover:bg-slate-50"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -133,7 +133,7 @@ const asArray = (x: any) =>
 // finder
 async function findProductBySlug(slug: string): Promise<Found | null> {
   const target = slug.toLowerCase();
-  // console.log("[product-detail] resolving", slug);
+  console.log("[product-detail] resolving slug:", slug);
 
   // Borosil (grouped -> variants)
   if (Array.isArray(borosilProducts)) {
@@ -143,7 +143,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
         const prod = { ...v, brand: "Borosil" };
         const cands = candidateSlugs(prod, g);
         if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          // console.log("[product-detail] match", { brand: "Borosil", via: "candidateSlugs|code|contains" });
+          console.log("[product-detail] MATCH", { brand: "Borosil", via: "candidates|code|contains" });
           return { product: { ...prod, productName: nameFrom(prod, g) }, group: g, brand: "Borosil" };
         }
       }
@@ -157,7 +157,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
       const prod = { ...p, brand: "Qualigens" };
       const cands = candidateSlugs(prod);
       if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        // console.log("[product-detail] match", { brand: "Qualigens", via: "candidateSlugs|code|contains" });
+        console.log("[product-detail] MATCH", { brand: "Qualigens", via: "candidates|code|contains" });
         return { product: prod, brand: "Qualigens" };
       }
     }
@@ -172,7 +172,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
         const prod = { ...v, brand: "Rankem" };
         const cands = candidateSlugs(prod, grp);
         if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          // console.log("[product-detail] match", { brand: "Rankem", via: "candidateSlugs|code|contains" });
+          console.log("[product-detail] MATCH", { brand: "Rankem", via: "candidates|code|contains" });
           return { product: prod, group: grp, brand: "Rankem" };
         }
       }
@@ -194,7 +194,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
       const prod = { ...p, brand: "HiMedia" };
       const cands = candidateSlugs(prod);
       if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        // console.log("[product-detail] match", { brand: "HiMedia", via: "candidateSlugs|code|contains" });
+        console.log("[product-detail] MATCH", { brand: "HiMedia", via: "candidates|code|contains" });
         return { product: prod, brand: "HiMedia" };
       }
     }
@@ -209,7 +209,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
         const prod = { ...v, brand: "Omsons" };
         const cands = candidateSlugs(prod, sec);
         if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          // console.log("[product-detail] match", { brand: "Omsons", via: "candidateSlugs|code|contains" });
+          console.log("[product-detail] MATCH", { brand: "Omsons", via: "candidates|code|contains" });
           return { product: prod, group: sec, brand: "Omsons" };
         }
       }
@@ -230,7 +230,7 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
         };
         const cands = candidateSlugs(merged, parent);
         if (cands.includes(target) || looksLikeCodeMatch(target, merged) || slugContainsCode(target, merged)) {
-          // console.log("[product-detail] match", { brand: "Avarice", via: "candidateSlugs|code|contains" });
+          console.log("[product-detail] MATCH", { brand: "Avarice", via: "candidates|code|contains" });
           return { product: merged, group: parent, brand: "Avarice" };
         }
       }
@@ -245,12 +245,13 @@ async function findProductBySlug(slug: string): Promise<Found | null> {
       const prod = { ...v, brand: "Whatman" };
       const cands = candidateSlugs(prod, grp);
       if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        // console.log("[product-detail] match", { brand: "Whatman", via: "candidateSlugs|code|contains" });
+        console.log("[product-detail] MATCH", { brand: "Whatman", via: "candidates|code|contains" });
         return { product: prod, group: grp, brand: "Whatman" };
       }
     }
   }
 
+  console.warn("[product-detail] NOT FOUND", { slug });
   return null;
 }
 
@@ -277,6 +278,15 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 // page (no images)
 export default async function ProductPage({ params }: { params: { slug: string } }) {
   const found = await findProductBySlug(params.slug);
+  console.log("[product-detail] render", {
+    slug: params.slug,
+    brand: found?.brand || found?.product?.brand,
+    name:
+      found?.product?.name ||
+      found?.product?.productName ||
+      found?.product?.title,
+    code: codeFrom(found?.product),
+  });
   if (!found) return notFound();
 
   const { product, group, brand: forcedBrand } = found;

--- a/lib/supabase/browser-client.ts
+++ b/lib/supabase/browser-client.ts
@@ -5,7 +5,15 @@ export function createSupabaseBrowserClient() {
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error("Supabase URL and/or Anon Key are missing from environment variables.")
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[diagnostics] Supabase env not set; skipping Supabase init"
+      )
+      return undefined as unknown as ReturnType<typeof createBrowserClient>
+    }
+    throw new Error(
+      "Supabase URL and/or Anon Key are missing from environment variables."
+    )
   }
 
   // Create a supabase client on the browser with project's credentials

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -11,6 +11,12 @@ export function createClient(): SupabaseClient {
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
   if (!url || !anon) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[diagnostics] Supabase env not set; skipping Supabase init"
+      )
+      return undefined as unknown as SupabaseClient
+    }
     throw new Error(
       "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY. Set them in .env.local / Vercel."
     )

--- a/scripts/smoke-product.ts
+++ b/scripts/smoke-product.ts
@@ -1,0 +1,95 @@
+// ts-node friendly script to validate resolver for a given slug
+
+import whatman from "@/lib/whatman_products.json";
+import borosil from "@/lib/borosil_products_absolute_final.json";
+import qualigens from "@/lib/qualigens-products.json";
+import rankem from "@/lib/rankem_products.json";
+import omsons from "@/lib/omsons_products.json";
+import avarice from "@/lib/avarice_products.json";
+import himedia from "@/lib/himedia_products_grouped";
+
+const norm = (s: any) => String(s ?? "").toLowerCase();
+const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+const first = (...vals: any[]) => {
+  for (const v of vals) { const s = typeof v === "string" ? v.trim() : ""; if (s) return s; }
+  return "";
+};
+
+function packFrom(p: any) {
+  return first(p.packSize, p.size, p.capacity, p.volume, p.diameter, p.dimensions, p.grade, p.Pack, p["Pack Size"], p.packing);
+}
+function codeFrom(p: any) {
+  const direct = first(p.code, p.product_code, p.productCode, p.catalog_no, p.catalogNo, p.cat_no, p.catno, p["Product Code"], p["Cat No"], p["Cat No."], p["Catalogue No"], p["Catalog No"], p["Code"], p.sku, p.item_code, p.itemCode);
+  if (direct) return direct;
+  const nameLike = first(p.name, p.title, p.productName, p["Product Name"], p.description);
+  if (!nameLike) return "";
+  const tokens = String(nameLike).split(/[\s,/()_-]+/).filter(Boolean);
+  const bad = /^(mm|ml|l|pk|pcs?|um|µm|gm|kg|g|x|mmf)$/i;
+  const candidates = tokens.filter(t => /\d/.test(t) && /^[a-z0-9-]+$/i.test(t) && !bad.test(t) && !/(mm|ml|l|µm|um)$/i.test(t));
+  const alnum = candidates.filter(t => /[a-z]/i.test(t)).sort((a,b)=>a.length-b.length);
+  return alnum[0] || candidates.find(t => /^\d{3,8}$/.test(t)) || "";
+}
+function brandFrom(p: any, g?: any) {
+  return first(p.brand, g?.brand, p.vendor, p.mfg, /borosil/i.test(JSON.stringify(p)) ? "Borosil" : "");
+}
+function nameFrom(p: any, g?: any) {
+  return first(p.productName, p.name, p.title, g?.title, g?.product, p.product, p["Product Name"]);
+}
+const makeSlug = (...parts: any[]) => parts.map((s:any)=>String(s||"").toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/(^-|-$)/g,"")).filter(Boolean).join("-");
+
+function candidateSlugs(p: any, g?: any) {
+  const b = brandFrom(p,g), n = nameFrom(p,g), pk = packFrom(p), c = codeFrom(p);
+  return [
+    makeSlug(b,n,pk,c), makeSlug(b,n,pk), makeSlug(b,n,c), makeSlug(b,n),
+    makeSlug(n,pk), makeSlug(n,pk,c), makeSlug(b,c), makeSlug(c)
+  ].filter(Boolean);
+}
+
+function scan() {
+  const pile: any[] = [];
+  // Whatman
+  const wv = Array.isArray((whatman as any)?.variants) ? (whatman as any).variants : [];
+  wv.forEach((p:any)=>pile.push({ brand:"Whatman", p, g:whatman }));
+  // Borosil
+  (Array.isArray(borosil) ? (borosil as any[]) : []).forEach((g:any)=>{
+    (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Borosil", p, g }));
+  });
+  // Rankem
+  (Array.isArray(rankem) ? (rankem as any[]) : []).forEach((g:any)=>{
+    (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Rankem", p, g }));
+  });
+  // Qualigens (flat)
+  const qarr = Array.isArray((qualigens as any).data) ? (qualigens as any).data : (Array.isArray(qualigens)? (qualigens as any[]): []);
+  qarr.forEach((p:any)=>pile.push({ brand:"Qualigens", p }));
+  // Omsons
+  const oc = (omsons as any)?.catalog || [];
+  oc.forEach((g:any)=> (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Omsons", p, g })));
+  // Avarice
+  const av = Array.isArray((avarice as any).data) ? (avarice as any).data : (Array.isArray(avarice)? (avarice as any[]): []);
+  av.forEach((parent:any)=> (parent.variants||[]).forEach((v:any)=>pile.push({ brand:"Avarice", p:{...v, product_name:parent.product_name, product_code:parent.product_code}, g:parent })));
+  // HiMedia (nested)
+  const hm = Array.isArray(himedia) ? (himedia as any[]) : [];
+  hm.forEach((sec:any)=> sec?.header_sections?.forEach((h:any)=> h?.sub_sections?.forEach((s:any)=> s?.products?.forEach((p:any)=> pile.push({ brand:"HiMedia", p })))));
+
+  return pile;
+}
+
+function main() {
+  const slug = process.argv[2] || "";
+  if (!slug) { console.error("Usage: ts-node scripts/smoke-product.ts <slug>"); process.exit(1); }
+  const target = slugify(slug);
+  const pile = scan();
+  const hits = pile.filter(({p,g}:any)=> {
+    const cands = candidateSlugs(p,g);
+    const code = codeFrom(p);
+    return cands.includes(target) || (code && slugify(String(code))===target) || (code && target.includes(slugify(String(code))));
+  });
+  console.log("TARGET:", target, "TOTAL:", pile.length, "HITS:", hits.length);
+  console.log(hits.slice(0,5).map(h=>({
+    brand:h.brand,
+    name: nameFrom(h.p,h.g),
+    code: codeFrom(h.p),
+    slug: candidateSlugs(h.p,h.g)[0]
+  })));
+}
+main();


### PR DESCRIPTION
## Summary
- avoid Supabase client errors in development when env vars are missing
- add global and product page error boundaries for clearer stack traces
- log slug resolution and rendering details for product pages and add CLI smoke test

## Testing
- `npx ts-node --transpile-only scripts/smoke-product.ts "whatman-0048-32mm-1000-pk"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: interactive ESLint config prompt)*
- `npm run dev` and request `/product/whatman-0048-32mm-1000-pk` *(shows resolver match and params.slug error in generateMetadata)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1243378832c9b74b8d0209b6034