### PR TITLE
chore: add product debugging helpers

### DIFF
--- a/app/api/debug/product/[slug]/route.ts
+++ b/app/api/debug/product/[slug]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+export async function GET(_: Request, { params }: { params: { slug: string } }) {
+  try {
+    const { findProductBySlug } = await import("@/app/product/[slug]/page");
+    const found = await findProductBySlug(params.slug);
+    return NextResponse.json({
+      ok: !!found,
+      slug: params.slug,
+      brand: found?.brand || found?.product?.brand || null,
+      sample: found
+        ? Object.fromEntries(
+            Object.entries(found.product || {}).slice(0, 12)
+          )
+        : null,
+    });
+  } catch (e: any) {
+    console.error("[api/debug/product]", e);
+    return NextResponse.json(
+      { ok: false, error: String(e?.message || e) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -131,9 +131,9 @@ const asArray = (x: any) =>
   Array.isArray(x?.data) ? x.data : Array.isArray(x) ? x : [];
 
 // finder
-async function findProductBySlug(slug: string): Promise<Found | null> {
+export async function findProductBySlug(slug: string): Promise<Found | null> {
   const target = slug.toLowerCase();
-  console.log("[product-detail] resolving slug:", slug);
+  console.log("[product-detail] resolving:", slug);
 
   // Borosil (grouped -> variants)
   if (Array.isArray(borosilProducts)) {
@@ -278,14 +278,10 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 // page (no images)
 export default async function ProductPage({ params }: { params: { slug: string } }) {
   const found = await findProductBySlug(params.slug);
-  console.log("[product-detail] render", {
+  console.log("[product-detail] render payload", {
     slug: params.slug,
     brand: found?.brand || found?.product?.brand,
-    name:
-      found?.product?.name ||
-      found?.product?.productName ||
-      found?.product?.title,
-    code: codeFrom(found?.product),
+    keys: found ? Object.keys(found.product || {}) : [],
   });
   if (!found) return notFound();
 

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -7,12 +7,16 @@ let _admin: SupabaseClient | null = null
 export function getSupabaseAdmin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const hasSupabaseEnv = !!url && !!serviceRole
 
-  if (!url || !serviceRole) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[supabase-admin] Missing URL or SERVICE_ROLE; returning null client")
-    }
+  if (!hasSupabaseEnv && process.env.NODE_ENV !== "production") {
+    console.warn("[diagnostics] Supabase env not set; skipping Supabase init in dev.")
     return null as unknown as SupabaseClient
+  }
+  if (!hasSupabaseEnv) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY."
+    )
   }
 
   if (!_admin) {

--- a/lib/supabase/browser-client.ts
+++ b/lib/supabase/browser-client.ts
@@ -3,14 +3,13 @@ import { createBrowserClient } from "@supabase/ssr"
 export function createSupabaseBrowserClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const hasSupabaseEnv = !!supabaseUrl && !!supabaseAnonKey
 
-  if (!supabaseUrl || !supabaseAnonKey) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn(
-        "[diagnostics] Supabase env not set; skipping Supabase init"
-      )
-      return undefined as unknown as ReturnType<typeof createBrowserClient>
-    }
+  if (!hasSupabaseEnv && process.env.NODE_ENV !== "production") {
+    console.warn("[diagnostics] Supabase env not set; skipping Supabase init in dev.")
+    return undefined as unknown as ReturnType<typeof createBrowserClient>
+  }
+  if (!hasSupabaseEnv) {
     throw new Error(
       "Supabase URL and/or Anon Key are missing from environment variables."
     )

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -9,14 +9,13 @@ export function createClient(): SupabaseClient {
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const hasSupabaseEnv = !!url && !!anon
 
-  if (!url || !anon) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn(
-        "[diagnostics] Supabase env not set; skipping Supabase init"
-      )
-      return undefined as unknown as SupabaseClient
-    }
+  if (!hasSupabaseEnv && process.env.NODE_ENV !== "production") {
+    console.warn("[diagnostics] Supabase env not set; skipping Supabase init in dev.")
+    return undefined as unknown as SupabaseClient
+  }
+  if (!hasSupabaseEnv) {
     throw new Error(
       "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY. Set them in .env.local / Vercel."
     )

--- a/lib/supabase/server-client.ts
+++ b/lib/supabase/server-client.ts
@@ -5,13 +5,16 @@ import { createServerClient, type CookieOptions } from "@supabase/ssr"
 export function getServerSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const hasSupabaseEnv = !!url && !!key
 
-  // Don't throw during build/prerender — just return null-like client
-  if (!url || !key) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[supabase] Env missing at build/prerender; returning null client")
-    }
+  if (!hasSupabaseEnv && process.env.NODE_ENV !== "production") {
+    console.warn("[diagnostics] Supabase env not set; skipping Supabase init in dev.")
     return null as unknown as ReturnType<typeof createServerClient>
+  }
+  if (!hasSupabaseEnv) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY."
+    )
   }
 
   // Create a normal server client

--- a/scripts/smoke-product.ts
+++ b/scripts/smoke-product.ts
@@ -1,5 +1,3 @@
-// ts-node friendly script to validate resolver for a given slug
-
 import whatman from "@/lib/whatman_products.json";
 import borosil from "@/lib/borosil_products_absolute_final.json";
 import qualigens from "@/lib/qualigens-products.json";
@@ -8,88 +6,63 @@ import omsons from "@/lib/omsons_products.json";
 import avarice from "@/lib/avarice_products.json";
 import himedia from "@/lib/himedia_products_grouped";
 
-const norm = (s: any) => String(s ?? "").toLowerCase();
 const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
-const first = (...vals: any[]) => {
-  for (const v of vals) { const s = typeof v === "string" ? v.trim() : ""; if (s) return s; }
-  return "";
-};
+const norm = (x:any) => String(x ?? "");
+const first = (...vals:any[]) => { for (const v of vals) { const s = typeof v==="string"? v.trim(): ""; if (s) return s; } return ""; };
 
-function packFrom(p: any) {
+function packFrom(p:any) {
   return first(p.packSize, p.size, p.capacity, p.volume, p.diameter, p.dimensions, p.grade, p.Pack, p["Pack Size"], p.packing);
 }
-function codeFrom(p: any) {
+function codeFrom(p:any) {
   const direct = first(p.code, p.product_code, p.productCode, p.catalog_no, p.catalogNo, p.cat_no, p.catno, p["Product Code"], p["Cat No"], p["Cat No."], p["Catalogue No"], p["Catalog No"], p["Code"], p.sku, p.item_code, p.itemCode);
   if (direct) return direct;
   const nameLike = first(p.name, p.title, p.productName, p["Product Name"], p.description);
   if (!nameLike) return "";
   const tokens = String(nameLike).split(/[\s,/()_-]+/).filter(Boolean);
   const bad = /^(mm|ml|l|pk|pcs?|um|µm|gm|kg|g|x|mmf)$/i;
-  const candidates = tokens.filter(t => /\d/.test(t) && /^[a-z0-9-]+$/i.test(t) && !bad.test(t) && !/(mm|ml|l|µm|um)$/i.test(t));
-  const alnum = candidates.filter(t => /[a-z]/i.test(t)).sort((a,b)=>a.length-b.length);
-  return alnum[0] || candidates.find(t => /^\d{3,8}$/.test(t)) || "";
+  const cands = tokens.filter(t => /\d/.test(t) && /^[a-z0-9-]+$/i.test(t) && !bad.test(t) && !/(mm|ml|l|µm|um)$/i.test(t));
+  const alnum = cands.filter(t => /[a-z]/i.test(t)).sort((a,b)=>a.length-b.length);
+  return alnum[0] || cands.find(t => /^\d{3,8}$/.test(t)) || "";
 }
-function brandFrom(p: any, g?: any) {
-  return first(p.brand, g?.brand, p.vendor, p.mfg, /borosil/i.test(JSON.stringify(p)) ? "Borosil" : "");
-}
-function nameFrom(p: any, g?: any) {
-  return first(p.productName, p.name, p.title, g?.title, g?.product, p.product, p["Product Name"]);
-}
-const makeSlug = (...parts: any[]) => parts.map((s:any)=>String(s||"").toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/(^-|-$)/g,"")).filter(Boolean).join("-");
+function brandFrom(p:any,g?:any){ return first(p.brand, g?.brand, p.vendor, p.mfg, /borosil/i.test(JSON.stringify(p)) ? "Borosil" : ""); }
+function nameFrom(p:any,g?:any){ return first(p.productName, p.name, p.title, g?.title, g?.product, p.product, p["Product Name"]); }
+const makeSlug = (...parts:any[]) => parts.map((s:any)=>slugify(String(s||""))).filter(Boolean).join("-");
 
-function candidateSlugs(p: any, g?: any) {
-  const b = brandFrom(p,g), n = nameFrom(p,g), pk = packFrom(p), c = codeFrom(p);
-  return [
-    makeSlug(b,n,pk,c), makeSlug(b,n,pk), makeSlug(b,n,c), makeSlug(b,n),
-    makeSlug(n,pk), makeSlug(n,pk,c), makeSlug(b,c), makeSlug(c)
-  ].filter(Boolean);
+function candidateSlugs(p:any,g?:any){
+  const b=brandFrom(p,g), n=nameFrom(p,g), pk=packFrom(p), c=codeFrom(p);
+  return [ makeSlug(b,n,pk,c), makeSlug(b,n,pk), makeSlug(b,n,c), makeSlug(b,n), makeSlug(n,pk), makeSlug(n,pk,c), makeSlug(b,c), makeSlug(c) ].filter(Boolean);
 }
 
-function scan() {
-  const pile: any[] = [];
-  // Whatman
-  const wv = Array.isArray((whatman as any)?.variants) ? (whatman as any).variants : [];
-  wv.forEach((p:any)=>pile.push({ brand:"Whatman", p, g:whatman }));
-  // Borosil
-  (Array.isArray(borosil) ? (borosil as any[]) : []).forEach((g:any)=>{
-    (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Borosil", p, g }));
-  });
-  // Rankem
-  (Array.isArray(rankem) ? (rankem as any[]) : []).forEach((g:any)=>{
-    (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Rankem", p, g }));
-  });
-  // Qualigens (flat)
-  const qarr = Array.isArray((qualigens as any).data) ? (qualigens as any).data : (Array.isArray(qualigens)? (qualigens as any[]): []);
-  qarr.forEach((p:any)=>pile.push({ brand:"Qualigens", p }));
-  // Omsons
-  const oc = (omsons as any)?.catalog || [];
-  oc.forEach((g:any)=> (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Omsons", p, g })));
-  // Avarice
-  const av = Array.isArray((avarice as any).data) ? (avarice as any).data : (Array.isArray(avarice)? (avarice as any[]): []);
-  av.forEach((parent:any)=> (parent.variants||[]).forEach((v:any)=>pile.push({ brand:"Avarice", p:{...v, product_name:parent.product_name, product_code:parent.product_code}, g:parent })));
-  // HiMedia (nested)
-  const hm = Array.isArray(himedia) ? (himedia as any[]) : [];
-  hm.forEach((sec:any)=> sec?.header_sections?.forEach((h:any)=> h?.sub_sections?.forEach((s:any)=> s?.products?.forEach((p:any)=> pile.push({ brand:"HiMedia", p })))));
-
-  return pile;
-}
-
-function main() {
+function main(){
   const slug = process.argv[2] || "";
   if (!slug) { console.error("Usage: ts-node scripts/smoke-product.ts <slug>"); process.exit(1); }
   const target = slugify(slug);
-  const pile = scan();
+  const pile:any[] = [];
+
+  // fill pile with rows from all catalogs (same shape as resolver)
+  const wv = Array.isArray((whatman as any)?.variants) ? (whatman as any).variants : [];
+  wv.forEach((p:any)=>pile.push({ brand:"Whatman", p, g:whatman }));
+  (Array.isArray(borosil)?(borosil as any[]):[]).forEach((g:any)=> (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Borosil", p, g })));
+  (Array.isArray(rankem)?(rankem as any[]):[]).forEach((g:any)=> (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Rankem", p, g })));
+  const qarr = Array.isArray((qualigens as any).data) ? (qualigens as any).data : (Array.isArray(qualigens)? (qualigens as any[]): []);
+  qarr.forEach((p:any)=>pile.push({ brand:"Qualigens", p }));
+  const oc = (omsons as any)?.catalog || [];
+  oc.forEach((g:any)=> (g.variants||[]).forEach((p:any)=>pile.push({ brand:"Omsons", p, g })));
+  const av = Array.isArray((avarice as any).data) ? (avarice as any).data : (Array.isArray(avarice)? (avarice as any[]): []);
+  av.forEach((parent:any)=> (parent.variants||[]).forEach((v:any)=>pile.push({ brand:"Avarice", p:{...v, product_name:parent.product_name, product_code:parent.product_code}, g:parent })));
+  const hm = Array.isArray(himedia)? (himedia as any[]): [];
+  hm.forEach((sec:any)=> sec?.header_sections?.forEach((h:any)=> h?.sub_sections?.forEach((s:any)=> s?.products?.forEach((p:any)=> pile.push({ brand:"HiMedia", p })))));
+
   const hits = pile.filter(({p,g}:any)=> {
     const cands = candidateSlugs(p,g);
-    const code = codeFrom(p);
+    const code  = codeFrom(p);
     return cands.includes(target) || (code && slugify(String(code))===target) || (code && target.includes(slugify(String(code))));
   });
+
   console.log("TARGET:", target, "TOTAL:", pile.length, "HITS:", hits.length);
-  console.log(hits.slice(0,5).map(h=>({
-    brand:h.brand,
-    name: nameFrom(h.p,h.g),
-    code: codeFrom(h.p),
-    slug: candidateSlugs(h.p,h.g)[0]
-  })));
+  if (hits[0]) {
+    const h = hits[0];
+    console.log({ brand: h.brand, name: nameFrom(h.p,h.g), code: codeFrom(h.p), slug: candidateSlugs(h.p,h.g)[0] });
+  }
 }
 main();


### PR DESCRIPTION
## Summary
- guard Supabase client setup when env vars are missing
- expose product resolver logs and debug API route
- add smoke test script for catalog slug checks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive setup prompt)
- `curl -sS http://localhost:3000/api/debug/product/whatman-0048-32mm-1000-pk`
- `curl -sS http://localhost:3000/product/whatman-0048-32mm-1000-pk > /tmp/product.html`


------
https://chatgpt.com/codex/tasks/task_e_68a0b4ad7c80832cb9140287e563cbcb