### PR TITLE
feat: unify product resolution using shared catalog index

### DIFF
--- a/app/api/debug/product/[slug]/route.ts
+++ b/app/api/debug/product/[slug]/route.ts
@@ -1,24 +1,13 @@
 import { NextResponse } from "next/server";
+import { getBySlug } from "@/lib/product-index";
 
-export async function GET(_: Request, { params }: { params: { slug: string } }) {
-  try {
-    const { findProductBySlug } = await import("@/app/product/[slug]/page");
-    const found = await findProductBySlug(params.slug);
-    return NextResponse.json({
-      ok: !!found,
-      slug: params.slug,
-      brand: found?.brand || found?.product?.brand || null,
-      sample: found
-        ? Object.fromEntries(
-            Object.entries(found.product || {}).slice(0, 12)
-          )
-        : null,
-    });
-  } catch (e: any) {
-    console.error("[api/debug/product]", e);
-    return NextResponse.json(
-      { ok: false, error: String(e?.message || e) },
-      { status: 500 }
-    );
-  }
+export async function GET(_req: Request, { params }: { params: { slug: string } }) {
+  const rec = getBySlug(params.slug);
+  return NextResponse.json({
+    ok: !!rec,
+    slug: params.slug,
+    foundBrand: rec?.brand ?? null,
+    name: rec?.name ?? null,
+    code: rec?.code ?? null
+  });
 }

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// app/product/[slug]/page.tsx
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
@@ -8,296 +7,28 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { getProductSEO } from "@/lib/seo";
+import { getBySlug } from "@/lib/product-index";
+import { makeSlug } from "@/lib/catalog/fields";
 
-// Static imports of catalogs
-import borosilProducts from "@/lib/borosil_products_absolute_final.json";
-import qualigensProductsRaw from "@/lib/qualigens-products.json";
-import rankemProducts from "@/lib/rankem_products.json";
-import omsonsDataRaw from "@/lib/omsons_products.json";
-import avariceProductsRaw from "@/lib/avarice_products.json";
-import himediaProductsRaw from "@/lib/himedia_products_grouped";
-import whatmanProducts from "@/lib/whatman_products.json";
-
-// --- utils ---
-const clean = (v: any) => (typeof v === "string" ? v.trim() : "");
-const first = (...vals: any[]) => clean(vals.find((x) => clean(x)) || "");
-const slugPart = (s: any) =>
-  typeof s === "string" && s.trim()
-    ? s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")
-    : "";
-const makeSlug = (...parts: any[]) => parts.map(slugPart).filter(Boolean).join("-");
-
-function packFrom(p: any) {
-  return first(
-    p.packSize, p.size, p.capacity, p.volume, p.diameter, p.dimensions, p.grade,
-    p.Pack, p["Pack Size"], p.packing, p["Pack"], p["Qty/Pack"], p["Quantity/Pack"]
-  );
-}
-function codeFrom(p: any) {
-  const direct = first(
-    p.code, p.product_code, p.productCode,
-    p.catalog_no, p.catalogNo,
-    p.cat_no, p.catno, p["Cat No"], p["Cat No."], p["CAT NO"], p["CAT. NO."],
-    p.catalogue_no, p.catalogueNo, p["Catalogue No"], p["Catalogue No."], p["Catalog No"],
-    p["Product Code"], p.productcode,
-    p.order_code, p.orderCode,
-    p.sku, p.item_code, p.itemCode, p.code_no, p["Code"]
-  );
-  if (direct) return direct;
-
-  // fallback: extract a code-like token from name/title
-  const nameLike = first(p.name, p.title, p.productName, p["Product Name"], p.description);
-  if (nameLike) {
-    const bad = /^(mm|ml|l|pk|pcs?|um|µm|gm|kg|g|x|mmf)$/i;
-    const tokens = String(nameLike).split(/[\s,/()_-]+/).filter(Boolean);
-    const candidates = tokens.filter(t => {
-      const T = t.toLowerCase();
-      if (bad.test(T)) return false;
-      if (!/^[a-z0-9-]+$/i.test(t)) return false;
-      if (!/\d/.test(t)) return false;
-      if (/(mm|ml|l|µm|um)$/i.test(T)) return false;
-      return t.length >= 3 && t.length <= 12;
-    });
-    const alnum = candidates.filter(t => /[a-z]/i.test(t) && /\d/.test(t)).sort((a,b)=>a.length-b.length);
-    if (alnum[0]) return alnum[0];
-    const numeric = candidates.filter(t => /^\d{3,8}$/.test(t)).sort((a,b)=>a.length-b.length);
-    if (numeric[0]) return numeric[0];
-  }
-  return "";
-}
-function brandFrom(p: any, g?: any) {
-  return first(
-    p.brand, g?.brand, p.vendor, p.mfg,
-    /borosil/i.test(JSON.stringify(p)) ? "Borosil" : ""
-  );
-}
-function nameFrom(p: any, g?: any) {
-  return first(
-    p.productName, p.name, p.title, g?.title, g?.product, p.product, p["Product Name"]
-  );
-}
-function priceFrom(p: any) {
-  if (p == null) return undefined;
-  if (typeof p === "number") return Number.isFinite(p) ? p : undefined;
-  const txt = String(p).trim().toUpperCase();
-  if (txt === "POR" || txt === "P.O.R" || txt === "P O R") return undefined;
-  const num = parseFloat(String(p).replace(/[^\d.]/g, ""));
-  return Number.isFinite(num) ? num : undefined;
-}
-
-// old single candidate kept for compatibility
-const candidateSlugLegacy = (p: any, g?: any) => {
-  const brand = brandFrom(p, g);
-  const name  = nameFrom(p, g);
-  const pack  = packFrom(p);
-  const code  = codeFrom(p);
-  const base = [brand, name, pack, code].filter(Boolean);
-  return makeSlug(...base);
-};
-
-// NEW: allow multiple slug variants (with or without code)
-function candidateSlugs(p: any, g?: any): string[] {
-  const brand = brandFrom(p, g);
-  const name  = nameFrom(p, g);
-  const pack  = packFrom(p);
-  const code  = codeFrom(p);
-
-  const cands = new Set<string>([
-    makeSlug(brand, name, pack, code), // full
-    makeSlug(brand, name, pack),       // no code
-    makeSlug(brand, name, code),
-    makeSlug(brand, name),
-    makeSlug(name, pack),
-    makeSlug(name, pack, code),
-    makeSlug(brand, code),
-    makeSlug(code),
-    candidateSlugLegacy(p, g),
-  ]);
-  return Array.from(cands).filter(Boolean);
-}
-
-function looksLikeCodeMatch(target: string, p: any) {
-  const c = codeFrom(p);
-  return c && makeSlug(String(c)) === target;
-}
-function slugContainsCode(target: string, p: any) {
-  const c = codeFrom(p);
-  if (!c) return false;
-  return target.includes(makeSlug(String(c)));
-}
-
-type Found = { product: any; group?: any; brand?: string };
-const asArray = (x: any) =>
-  Array.isArray(x?.data) ? x.data : Array.isArray(x) ? x : [];
-
-// finder
-export async function findProductBySlug(slug: string): Promise<Found | null> {
-  const target = slug.toLowerCase();
-  console.log("[product-detail] resolving:", slug);
-
-  // Borosil (grouped -> variants)
-  if (Array.isArray(borosilProducts)) {
-    for (const g of borosilProducts as any[]) {
-      const variants = Array.isArray(g.variants) ? g.variants : [];
-      for (const v of variants) {
-        const prod = { ...v, brand: "Borosil" };
-        const cands = candidateSlugs(prod, g);
-        if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          console.log("[product-detail] MATCH", { brand: "Borosil", via: "candidates|code|contains" });
-          return { product: { ...prod, productName: nameFrom(prod, g) }, group: g, brand: "Borosil" };
-        }
-      }
-    }
-  }
-
-  // Qualigens (flat)
-  {
-    const arr = asArray((qualigensProductsRaw as any).default ?? qualigensProductsRaw);
-    for (const p of arr) {
-      const prod = { ...p, brand: "Qualigens" };
-      const cands = candidateSlugs(prod);
-      if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        console.log("[product-detail] MATCH", { brand: "Qualigens", via: "candidates|code|contains" });
-        return { product: prod, brand: "Qualigens" };
-      }
-    }
-  }
-
-  // Rankem (grouped -> variants)
-  {
-    const groups: any[] = Array.isArray(rankemProducts) ? (rankemProducts as any[]) : [];
-    for (const grp of groups) {
-      const variants = Array.isArray(grp?.variants) ? grp.variants : [];
-      for (const v of variants) {
-        const prod = { ...v, brand: "Rankem" };
-        const cands = candidateSlugs(prod, grp);
-        if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          console.log("[product-detail] MATCH", { brand: "Rankem", via: "candidates|code|contains" });
-          return { product: prod, group: grp, brand: "Rankem" };
-        }
-      }
-    }
-  }
-
-  // HiMedia (nested)
-  {
-    const root: any[] = Array.isArray(himediaProductsRaw) ? (himediaProductsRaw as any[]) : [];
-    const flat: any[] = [];
-    for (const section of root) {
-      for (const header of section.header_sections || []) {
-        for (const sub of header.sub_sections || []) {
-          for (const item of sub.products || []) flat.push(item);
-        }
-      }
-    }
-    for (const p of flat) {
-      const prod = { ...p, brand: "HiMedia" };
-      const cands = candidateSlugs(prod);
-      if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        console.log("[product-detail] MATCH", { brand: "HiMedia", via: "candidates|code|contains" });
-        return { product: prod, brand: "HiMedia" };
-      }
-    }
-  }
-
-  // Omsons (sections[].variants[])
-  {
-    const sections: any[] = Array.isArray((omsonsDataRaw as any)?.catalog) ? (omsonsDataRaw as any).catalog : [];
-    for (const sec of sections) {
-      const variants = Array.isArray(sec?.variants) ? sec.variants : [];
-      for (const v of variants) {
-        const prod = { ...v, brand: "Omsons" };
-        const cands = candidateSlugs(prod, sec);
-        if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-          console.log("[product-detail] MATCH", { brand: "Omsons", via: "candidates|code|contains" });
-          return { product: prod, group: sec, brand: "Omsons" };
-        }
-      }
-    }
-  }
-
-  // Avarice (products[].variants[])
-  {
-    const products: any[] = asArray((avariceProductsRaw as any).default ?? avariceProductsRaw);
-    for (const parent of products) {
-      for (const v of parent.variants || []) {
-        const merged = {
-          ...v,
-          product_name: parent.product_name,
-          product_code: parent.product_code,
-          cas_no: parent.cas_no,
-          brand: "Avarice",
-        };
-        const cands = candidateSlugs(merged, parent);
-        if (cands.includes(target) || looksLikeCodeMatch(target, merged) || slugContainsCode(target, merged)) {
-          console.log("[product-detail] MATCH", { brand: "Avarice", via: "candidates|code|contains" });
-          return { product: merged, group: parent, brand: "Avarice" };
-        }
-      }
-    }
-  }
-
-  // Whatman (group object with variants)
-  {
-    const grp: any = whatmanProducts as any;
-    const variants = Array.isArray(grp?.variants) ? grp.variants : [];
-    for (const v of variants) {
-      const prod = { ...v, brand: "Whatman" };
-      const cands = candidateSlugs(prod, grp);
-      if (cands.includes(target) || looksLikeCodeMatch(target, prod) || slugContainsCode(target, prod)) {
-        console.log("[product-detail] MATCH", { brand: "Whatman", via: "candidates|code|contains" });
-        return { product: prod, group: grp, brand: "Whatman" };
-      }
-    }
-  }
-
-  console.warn("[product-detail] NOT FOUND", { slug });
-  return null;
-}
-
-// metadata
 export async function generateMetadata({ params }: { params: { slug: string } }) {
-  const found = await findProductBySlug(params.slug);
-  if (!found) {
-    return {
-      title: "Product Not Found | Chemical Corporation",
-      description: "The requested product could not be found.",
-      robots: { index: false, follow: false },
-    };
+  const rec = getBySlug(params.slug);
+  if (!rec) {
+    return { title: "Product Not Found | Chemical Corporation", description: "The requested product could not be found.", robots: { index: false, follow: false } };
   }
-  const canonical = `/product/${params.slug}`;
-  const seo = getProductSEO(found.product, found.group, canonical);
-  return {
-    title: seo.title,
-    description: seo.description,
-    alternates: { canonical },
-    openGraph: { title: seo.title, description: seo.description, type: "product", url: canonical },
-  };
+  const canonical = `/product/${makeSlug(params.slug)}`;
+  const seo = getProductSEO(rec.raw, rec.group, canonical);
+  return { title: seo.title, description: seo.description, alternates: { canonical }, openGraph: { title: seo.title, description: seo.description, type: "product", url: canonical } };
 }
 
-// page (no images)
 export default async function ProductPage({ params }: { params: { slug: string } }) {
-  const found = await findProductBySlug(params.slug);
-  console.log("[product-detail] render payload", {
-    slug: params.slug,
-    brand: found?.brand || found?.product?.brand,
-    keys: found ? Object.keys(found.product || {}) : [],
-  });
-  if (!found) return notFound();
+  const rec = getBySlug(params.slug);
+  if (!rec) return notFound();
 
-  const { product, group, brand: forcedBrand } = found;
-  const canonical = `/product/${params.slug}`;
-  const seo = getProductSEO(product, group, canonical);
+  const canonical = `/product/${makeSlug(params.slug)}`;
+  const seo = getProductSEO(rec.raw, rec.group, canonical);
 
-  const brand = first(product.brand, forcedBrand);
-  const name = first(product.productName, product.name, product.title, product["Product Name"]);
-  const pack = packFrom(product);
-  const code = codeFrom(product);
-  const hsn = first(product.hsn, product.hsnCode, product["HSN Code"], product["HSN"]);
-  const cas = first(product.cas, product.casNo, product.cas_number, product["CAS No"], product["CAS"]);
-  const price = priceFrom((product as any).price ?? (product as any).Price ?? (product as any).rate ?? (product as any).price_inr);
-
-  const jsonLd = JSON.stringify(seo.jsonLd ?? {});
+  const priceNum = typeof rec.price === "number" ? rec.price : null;
+  const priceTxt = priceNum != null ? `₹${priceNum.toLocaleString("en-IN")}` : "POR";
 
   return (
     <div className="container mx-auto px-4 py-10">
@@ -310,19 +41,15 @@ export default async function ProductPage({ params }: { params: { slug: string }
       <Card className="bg-white">
         <CardContent className="p-6">
           <div className="flex flex-wrap gap-2 mb-4">
-            {brand ? <Badge variant="outline">{brand}</Badge> : null}
-            {pack ? <Badge variant="outline">{pack}</Badge> : null}
-            {code ? <Badge variant="outline">Code: {code}</Badge> : null}
-            {hsn ? <Badge variant="outline">HSN: {hsn}</Badge> : null}
-            {cas ? <Badge variant="outline">CAS: {cas}</Badge> : null}
+            {rec.brand ? <Badge variant="outline">{rec.brand}</Badge> : null}
+            {rec.pack ? <Badge variant="outline">{rec.pack}</Badge> : null}
+            {rec.code ? <Badge variant="outline">Code: {rec.code}</Badge> : null}
+            {rec.hsn ? <Badge variant="outline">HSN: {rec.hsn}</Badge> : null}
+            {rec.cas ? <Badge variant="outline">CAS: {rec.cas}</Badge> : null}
           </div>
 
-          <div className="text-2xl font-semibold text-slate-900 mb-2">
-            {price !== undefined ? `₹${price.toLocaleString("en-IN")}` : "POR"}
-          </div>
-          <div className="text-sm text-emerald-700 mb-6">
-            Discount applies in cart — final price shown at checkout
-          </div>
+          <div className="text-2xl font-semibold text-slate-900 mb-2">{priceTxt}</div>
+          <div className="text-sm text-emerald-700 mb-6">Discount applies in cart — final price shown at checkout</div>
 
           <div className="flex gap-3">
             <Button asChild><Link href="/products">Continue Shopping</Link></Button>
@@ -330,13 +57,13 @@ export default async function ProductPage({ params }: { params: { slug: string }
           </div>
 
           <p className="text-slate-700 mt-6">
-            Buy {brand ? `${brand} ` : ""}{name}{pack ? ` ${pack}` : ""} online.
+            Buy {rec.brand ? `${rec.brand} ` : ""}{rec.name}{rec.pack ? ` ${rec.pack}` : ""} online.
             10,000+ lab products from top brands with nationwide delivery.
           </p>
         </CardContent>
       </Card>
 
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(seo.jsonLd ?? {}) }} />
     </div>
   );
 }

--- a/lib/catalog/derive.ts
+++ b/lib/catalog/derive.ts
@@ -1,0 +1,44 @@
+import { firstNonEmpty, getField, codeKeys, nameKeys, packKeys, casKeys, hsnKeys } from "./fields";
+
+export function brandFrom(p: any, g?: any) {
+  const s = JSON.stringify(p || {});
+  return (
+    p?.brand || g?.brand || p?.vendor || p?.mfg ||
+    (/borosil/i.test(s) ? "Borosil" : "") ||
+    ""
+  );
+}
+
+export function nameFrom(p: any, g?: any) {
+  return firstNonEmpty(p, nameKeys()) || g?.title || g?.product || p?.product || "";
+}
+
+export function packFrom(p: any) {
+  return firstNonEmpty(p, packKeys());
+}
+
+export function codeFrom(p: any) {
+  const direct = getField(p, codeKeys());
+  if (direct) return direct;
+
+  // Fallback: extract code-like token from name/title
+  const nameLike = nameFrom(p);
+  if (nameLike) {
+    const tokens = String(nameLike).split(/[\s,/()_-]+/).filter(Boolean);
+    const bad = /^(mm|ml|l|pk|pcs?|um|µm|gm|kg|g|x|mmf)$/i;
+    const candidates = tokens.filter(t => {
+      const T = t.toLowerCase();
+      if (bad.test(T)) return false;
+      if (!/^[a-z0-9-]+$/i.test(t)) return false;
+      if (!/\d/.test(t)) return false;
+      if (/(mm|ml|l|µm|um)$/i.test(T)) return false;
+      return t.length >= 3 && t.length <= 12;
+    });
+    const alnum = candidates.filter(t => /[a-z]/i.test(t) && /\d/.test(t)).sort((a,b)=>a.length-b.length);
+    return alnum[0] || candidates.find(t => /^\d{3,8}$/.test(t)) || "";
+  }
+  return "";
+}
+
+export function hsnFrom(p: any) { return firstNonEmpty(p, hsnKeys()); }
+export function casFrom(p: any) { return firstNonEmpty(p, casKeys()); }

--- a/lib/catalog/fields.ts
+++ b/lib/catalog/fields.ts
@@ -1,0 +1,63 @@
+export const normalizeKey = (str: string) =>
+  String(str ?? "").toLowerCase().replace(/[^a-z0-9]/g, "_").replace(/_+/g, "_");
+
+export const clean = (v: any) => (typeof v === "string" ? v.trim() : "");
+export const firstNonEmpty = (obj: Record<string, any>, keys: string[]) => {
+  for (const k of keys) {
+    const nk = normalizeKey(k);
+    if (obj?.[k] !== undefined && obj?.[k] !== "") return obj[k];
+    if (obj?.[nk] !== undefined && obj?.[nk] !== "") return obj[nk];
+  }
+  return "";
+};
+
+export const codeKeys = () => [
+  "code","product_code","Product Code","productCode",
+  "cat_no","cat no","cat_no.","catno","Cat No","Cat No.",
+  "catalog_no","catalog number","catalogue_no","catalogue_number","Catalog No","Catalogue No","Catalogue No.",
+  "order_code","sku","item_code","itemCode","code_no","Code"
+];
+
+export const priceKeys = () => [
+  "price","Price","price_piece","price_/piece","Price /Piece","Price/ Piece","Price/ Each",
+  "list_price","offer_price","price_each","price_rs","price_(rs.)","Price (₹)","rate","Rate","Amount"
+];
+
+export const nameKeys = () => [
+  "Product Name","product_name","name","item","title","description","Description","item_description",
+  "material_name","chemical_name","product","product_title","material","material description","product_description"
+];
+
+export const packKeys = () => ["Pack Size","pack_size","Packsize","Packing","Pack","pack","package","Qty/Pack","Quantity/Pack"];
+export const casKeys  = () => ["CAS No","cas_no","cas","cas_number","CAS"];
+export const hsnKeys  = () => ["HSN Code","hsn_code","hsn","HSN"];
+
+export function getField(variant: any, keys: string[]) {
+  for (const k of keys) {
+    if (variant?.[k] !== undefined && variant?.[k] !== "") return variant[k];
+    const nk = normalizeKey(k);
+    if (variant?.[nk] !== undefined && variant?.[nk] !== "") return variant[nk];
+  }
+  return "";
+}
+
+export const isPOR = (v: any) => /^por$/i.test(String(v ?? "").trim());
+
+export function parsePriceToNumber(v: any): number | null {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (v == null) return null;
+  const s = String(v).trim();
+  if (isPOR(s)) return null;
+  const n = Number(s.replace(/[^\d.]/g, ""));
+  return Number.isFinite(n) ? n : null;
+}
+
+// Basic slug helpers
+export const slugify = (s: string) =>
+  s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+
+export const slugPart = (s: any) =>
+  typeof s === "string" && s.trim() ? slugify(s) : "";
+
+export const makeSlug = (...parts: any[]) =>
+  parts.map(slugPart).filter(Boolean).join("-");

--- a/lib/catalog/sources.ts
+++ b/lib/catalog/sources.ts
@@ -1,0 +1,148 @@
+import borosilRaw from "@/lib/borosil_products_absolute_final.json";
+import qualigensRaw from "@/lib/qualigens-products.json";
+import rankemRaw from "@/lib/rankem_products.json";
+import omsonsRaw from "@/lib/omsons_products.json";
+import avariceRaw from "@/lib/avarice_products.json";
+import himediaRaw from "@/lib/himedia_products_grouped";
+import whatmanRaw from "@/lib/whatman_products.json";
+
+import { brandFrom, nameFrom, packFrom, codeFrom, hsnFrom, casFrom } from "./derive";
+
+const borosil = (borosilRaw as any).default ?? borosilRaw;
+const qualigens = (qualigensRaw as any).default ?? qualigensRaw;
+const rankem = (rankemRaw as any).default ?? rankemRaw;
+const omsons = (omsonsRaw as any).default ?? omsonsRaw;
+const avarice = (avariceRaw as any).default ?? avariceRaw;
+const himedia = (himediaRaw as any).default ?? himediaRaw;
+const whatman = (whatmanRaw as any).default ?? whatmanRaw;
+
+type Row = { brand: string; name: string; pack: string; code: string; price?: number | string | null; hsn?: string; cas?: string; raw: any; group?: any };
+
+const asArray = (x: any) => Array.isArray(x?.data) ? x.data : Array.isArray(x) ? x : [];
+
+export function* iterAllProducts(): Generator<Row> {
+  // BOROSIL (grouped)
+  if (Array.isArray(borosil)) {
+    for (const g of borosil as any[]) {
+      const variants = Array.isArray(g.variants) ? g.variants : [];
+      for (const v of variants) {
+        const row = { ...v };
+        yield {
+          brand: "Borosil",
+          name: nameFrom(row, g),
+          pack: packFrom(row),
+          code: codeFrom(row),
+          price: row.price ?? row.Price ?? row.rate ?? null,
+          hsn: hsnFrom(row),
+          cas: casFrom(row),
+          raw: row,
+          group: g,
+        };
+      }
+    }
+  }
+
+  // QUALIGENS (flat or {data})
+  for (const p of asArray(qualigens)) {
+    yield {
+      brand: "Qualigens",
+      name: nameFrom(p),
+      pack: packFrom(p),
+      code: codeFrom(p),
+      price: p.Price ?? p.price ?? p.rate ?? null,
+      hsn: hsnFrom(p),
+      cas: casFrom(p),
+      raw: p,
+    };
+  }
+
+  // RANKEM (grouped)
+  for (const grp of (Array.isArray(rankem) ? (rankem as any[]) : [])) {
+    for (const v of grp.variants || []) {
+      yield {
+        brand: "Rankem",
+        name: nameFrom(v, grp),
+        pack: packFrom(v),
+        code: codeFrom(v),
+        price: v.Price ?? v.price ?? v.rate ?? null,
+        hsn: hsnFrom(v),
+        cas: casFrom(v),
+        raw: v,
+        group: grp,
+      };
+    }
+  }
+
+  // HIMEDIA (nested)
+  for (const section of (Array.isArray(himedia) ? (himedia as any[]) : [])) {
+    for (const header of section.header_sections || []) {
+      for (const sub of header.sub_sections || []) {
+        for (const item of sub.products || []) {
+          yield {
+            brand: "HiMedia",
+            name: nameFrom(item),
+            pack: packFrom(item),
+            code: codeFrom(item),
+            price: item.rate ?? item.price ?? null,
+            hsn: hsnFrom(item),
+            cas: casFrom(item),
+            raw: item,
+          };
+        }
+      }
+    }
+  }
+
+  // OMSONS (sections[].variants[])
+  for (const sec of ((omsons as any)?.catalog || [])) {
+    for (const v of sec.variants || []) {
+      yield {
+        brand: "Omsons",
+        name: nameFrom(v, sec),
+        pack: packFrom(v),
+        code: codeFrom(v),
+        price: v.Price ?? v.price ?? v.rate ?? null,
+        hsn: hsnFrom(v),
+        cas: casFrom(v),
+        raw: v,
+        group: sec,
+      };
+    }
+  }
+
+  // AVARICE ({data:[{variants:[]}]})
+  for (const parent of asArray(avarice)) {
+    for (const v of parent.variants || []) {
+      const merged = { ...v, product_name: parent.product_name, product_code: parent.product_code, cas_no: parent.cas_no };
+      yield {
+        brand: "Avarice",
+        name: nameFrom(merged, parent),
+        pack: packFrom(merged),
+        code: codeFrom(merged),
+        price: merged.price_inr ?? merged.rate ?? null,
+        hsn: hsnFrom(merged),
+        cas: casFrom(merged),
+        raw: merged,
+        group: parent,
+      };
+    }
+  }
+
+  // WHATMAN (group with variants)
+  {
+    const vr = Array.isArray((whatman as any)?.variants) ? (whatman as any).variants : [];
+    for (const v of vr) {
+      yield {
+        brand: "Whatman",
+        name: nameFrom(v, whatman),
+        pack: packFrom(v),
+        code: codeFrom(v),
+        price: v.price ?? v.Price ?? v.rate ?? null,
+        hsn: hsnFrom(v),
+        cas: casFrom(v),
+        raw: v,
+        group: whatman,
+      };
+    }
+  }
+}

--- a/lib/product-index.ts
+++ b/lib/product-index.ts
@@ -1,0 +1,52 @@
+import { iterAllProducts } from "./catalog/sources";
+import { makeSlug } from "./catalog/fields";
+
+export type ProductRecord = {
+  brand: string; name: string; pack: string; code: string;
+  price?: number|string|null; hsn?: string; cas?: string;
+  raw: any; group?: any;
+};
+
+let CACHE: {
+  bySlug: Map<string, ProductRecord>;
+  byCode: Map<string, ProductRecord>;
+} | null = null;
+
+function candidateSlugs(r: ProductRecord): string[] {
+  const { brand, name, pack, code } = r;
+  const set = new Set<string>([
+    makeSlug(brand, name, pack, code),
+    makeSlug(brand, name, pack),
+    makeSlug(brand, name, code),
+    makeSlug(brand, name),
+    makeSlug(name, pack),
+    makeSlug(name, pack, code),
+    makeSlug(brand, code),
+    makeSlug(code),
+  ]);
+  return Array.from(set).filter(Boolean);
+}
+
+export function ensureIndex() {
+  if (CACHE) return CACHE;
+  const bySlug = new Map<string, ProductRecord>();
+  const byCode = new Map<string, ProductRecord>();
+
+  for (const row of iterAllProducts()) {
+    const rec: ProductRecord = row;
+    const cands = candidateSlugs(rec);
+    for (const s of cands) if (!bySlug.has(s)) bySlug.set(s, rec);
+    if (rec.code) {
+      const c = makeSlug(String(rec.code));
+      if (!byCode.has(c)) byCode.set(c, rec);
+    }
+  }
+  CACHE = { bySlug, byCode };
+  return CACHE;
+}
+
+export function getBySlug(slug: string): ProductRecord | null {
+  const key = makeSlug(slug);
+  const { bySlug, byCode } = ensureIndex();
+  return bySlug.get(key) || byCode.get(key) || null;
+}


### PR DESCRIPTION
## Summary
- extract field normalization and slug utilities into server-safe catalog helpers
- build cross-brand catalog iterator and product index for slug/code lookups
- resolve product page via shared index and expose debug lookup API
- fix catalog source imports to handle default-exported JSON modules

## Testing
- ⚠️ `npm run lint` *(Next.js ESLint plugin recommendation)*
- ⚠️ `npm run build` *(terminated early in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc7a5f94832c8e993866f71b2afc